### PR TITLE
chore(api-core): core, angular, axios api naming consistency

### DIFF
--- a/packages/api-angular/src/index.js
+++ b/packages/api-angular/src/index.js
@@ -1,16 +1,16 @@
 import angular from 'angular';
 
 import avApiOptionsProvider from './options';
-import avApiFactory from './api';
-import avMicroserviceApiFactory from './ms';
+import AvApiFactory from './api';
+import AvMicroserviceApiFactory from './ms';
 
+import AvProxyApiFactory from './proxy';
 import avLogMessagesApiFactory from './logs';
 import avNavigationApiFactory from './navigation';
 import avNotificationApiFactory from './notification';
 import avOrganizationsApiFactory from './organizations';
 import avPermissionsApiFactory from './permissions';
 import avProvidersApiFactory from './providers';
-import avProxyApiFactory from './proxy';
 import avRegionsApiFactory from './regions';
 import avPdfApiFactory from './pdfs';
 import avSpacesApiFactory from './spaces';
@@ -22,16 +22,16 @@ import avSettingsApiFactory from './settings';
 export default angular
   .module('availity.api', ['ng'])
   .provider('avApiOptions', avApiOptionsProvider)
-  .factory('AvApi', avApiFactory)
-  .factory('AvMicroserviceApi', avMicroserviceApiFactory)
+  .factory('AvApi', AvApiFactory)
+  .factory('AvMicroserviceApi', AvMicroserviceApiFactory)
+  .factory('AvProxyApi', AvProxyApiFactory)
   .factory('avLogMessagesApi', avLogMessagesApiFactory)
   .factory('avPdfApi', avPdfApiFactory)
   .factory('avNavigationApi', avNavigationApiFactory)
-  .factory('avNotificationsApi', avNotificationApiFactory)
+  .factory('avNotificationApi', avNotificationApiFactory)
   .factory('avOrganizationsApi', avOrganizationsApiFactory)
   .factory('avPermissionsApi', avPermissionsApiFactory)
   .factory('avProvidersApi', avProvidersApiFactory)
-  .factory('AvProxyApi', avProxyApiFactory)
   .factory('avRegionsApi', avRegionsApiFactory)
   .factory('avSpacesApi', avSpacesApiFactory)
   .factory('avUsersApi', avUsersApiFactory)

--- a/packages/api-angular/src/logs.js
+++ b/packages/api-angular/src/logs.js
@@ -1,4 +1,5 @@
 import angular from 'angular';
+
 import { AvLogMessages } from '@availity/api-core';
 
 export default ($http, $q, avApiOptions) =>

--- a/packages/api-angular/src/tests/api.test.js
+++ b/packages/api-angular/src/tests/api.test.js
@@ -23,12 +23,12 @@ describe('Api Definitions Angular', () => {
     expect(avNavigationApi).toBeDefined();
   });
 
-  test('avNotificationsApi should be defined', () => {
-    let avNotificationsApi;
-    angular.mock.inject(_avNotificationsApi_ => {
-      avNotificationsApi = _avNotificationsApi_;
+  test('avNotificationApi should be defined', () => {
+    let avNotificationApi;
+    angular.mock.inject(_avNotificationApi_ => {
+      avNotificationApi = _avNotificationApi_;
     });
-    expect(avNotificationsApi).toBeDefined();
+    expect(avNotificationApi).toBeDefined();
   });
 
   test('avOrganizationsApi should be defined', () => {

--- a/packages/api-axios/src/index.js
+++ b/packages/api-axios/src/index.js
@@ -1,36 +1,36 @@
 import AvApi from './api';
-import AvMicroservice from './ms';
-import logMessagesApi from './logs';
-import navigationApi from './navigation';
-import notificationApi from './notification';
-import organizationsApi from './organizations';
-import permissionsApi from './permissions';
-import providersApi from './providers';
-import ProxyApi from './proxy';
-import regionsApi from './regions';
-import spacesApi from './spaces';
-import userApi from './user';
-import pdfApi from './pdf';
-import userPermissionsApi from './userPermissions';
-import filesApi from './files';
-import settingsApi from './settings';
+import AvMicroserviceApi from './ms';
+import AvProxyApi from './proxy';
+import avLogMessagesApi from './logs';
+import avNavigationApi from './navigation';
+import avNotificationApi from './notification';
+import avOrganizationsApi from './organizations';
+import avPermissionsApi from './permissions';
+import avProvidersApi from './providers';
+import avRegionsApi from './regions';
+import avSpacesApi from './spaces';
+import avUserApi from './user';
+import avPdfApi from './pdf';
+import avUserPermissionsApi from './userPermissions';
+import avFilesApi from './files';
+import avSettingsApi from './settings';
 
 export default AvApi;
 
 export {
-  AvMicroservice,
-  ProxyApi,
-  logMessagesApi,
-  navigationApi,
-  notificationApi,
-  organizationsApi,
-  permissionsApi,
-  providersApi,
-  regionsApi,
-  pdfApi,
-  spacesApi,
-  userApi,
-  userPermissionsApi,
-  filesApi,
-  settingsApi,
+  AvMicroserviceApi,
+  AvProxyApi,
+  avLogMessagesApi,
+  avNavigationApi,
+  avNotificationApi,
+  avOrganizationsApi,
+  avPermissionsApi,
+  avProvidersApi,
+  avRegionsApi,
+  avPdfApi,
+  avSpacesApi,
+  avUserApi,
+  avUserPermissionsApi,
+  avFilesApi,
+  avSettingsApi,
 };

--- a/packages/api-axios/src/notification.js
+++ b/packages/api-axios/src/notification.js
@@ -3,6 +3,7 @@ import utils from 'axios/lib/utils';
 import { AvNotification } from '@availity/api-core';
 
 const { merge } = utils;
+
 class AvNotificationApi extends AvNotification {
   constructor(options) {
     super({

--- a/packages/api-axios/src/tests/api.test.js
+++ b/packages/api-axios/src/tests/api.test.js
@@ -1,41 +1,44 @@
 import Api, {
-  logMessagesApi,
-  navigationApi,
-  notificationApi,
-  organizationsApi,
-  permissionsApi,
-  providersApi,
-  ProxyApi,
-  regionsApi,
-  spacesApi,
-  userApi,
-  userPermissionsApi,
-  filesApi,
-  settingsApi,
+  AvMicroserviceApi,
+  AvProxyApi,
+  avLogMessagesApi,
+  avNavigationApi,
+  avNotificationApi,
+  avOrganizationsApi,
+  avPermissionsApi,
+  avProvidersApi,
+  avRegionsApi,
+  avSpacesApi,
+  avUserApi,
+  avUserPermissionsApi,
+  avFilesApi,
+  avSettingsApi,
 } from '../';
 
 describe('AvAPi', () => {
   test('should be defined', () => {
     const api = new Api({});
     expect(api).toBeDefined();
-    const proxy = new ProxyApi({ tenant: 'healthplan' });
+    const proxy = new AvProxyApi({ tenant: 'healthplan' });
     expect(proxy).toBeDefined();
+    const ms = new AvMicroserviceApi({ path: 'urlPath' });
+    expect(ms).toBeDefined();
   });
 });
 
 describe('API Definitions', () => {
   test('should be defined', () => {
-    expect(logMessagesApi).toBeDefined();
-    expect(navigationApi).toBeDefined();
-    expect(notificationApi).toBeDefined();
-    expect(organizationsApi).toBeDefined();
-    expect(permissionsApi).toBeDefined();
-    expect(providersApi).toBeDefined();
-    expect(regionsApi).toBeDefined();
-    expect(spacesApi).toBeDefined();
-    expect(userApi).toBeDefined();
-    expect(userPermissionsApi).toBeDefined();
-    expect(filesApi).toBeDefined();
-    expect(settingsApi).toBeDefined();
+    expect(avLogMessagesApi).toBeDefined();
+    expect(avNavigationApi).toBeDefined();
+    expect(avNotificationApi).toBeDefined();
+    expect(avOrganizationsApi).toBeDefined();
+    expect(avPermissionsApi).toBeDefined();
+    expect(avProvidersApi).toBeDefined();
+    expect(avRegionsApi).toBeDefined();
+    expect(avSpacesApi).toBeDefined();
+    expect(avUserApi).toBeDefined();
+    expect(avUserPermissionsApi).toBeDefined();
+    expect(avFilesApi).toBeDefined();
+    expect(avSettingsApi).toBeDefined();
   });
 });

--- a/packages/authorizations-axios/src/index.js
+++ b/packages/authorizations-axios/src/index.js
@@ -1,9 +1,9 @@
 import AvAuthorizations from '@availity/authorizations-core';
-import { permissionsApi, regionsApi } from '@availity/api-axios';
+import { avPermissionsApi, avRegionsApi } from '@availity/api-axios';
 
 class AvAuthorizationsReact extends AvAuthorizations {
   constructor() {
-    super(permissionsApi, regionsApi, Promise);
+    super(avPermissionsApi, avRegionsApi, Promise);
   }
 }
 


### PR DESCRIPTION
https://github.com/Availity/sdk-js/issues/29
BREAKING CHANGE: export naming conventions have been refactored to match for each implementation (angular/axios). Constructors are prefixed with 'Av', implementations are prefixed with 'av', and Apis are postfixed with 'Api'.