### PR TITLE
fix(api-core): format postGet payload to standard

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -21,5 +21,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "qs": "^6.5.2"
   }
 }

--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -1,4 +1,5 @@
 import AvLocalStorage from '@availity/localstorage-core';
+import qs from 'qs';
 
 import API_OPTIONS from './options';
 
@@ -212,10 +213,19 @@ export default class AvApi {
     config.method = 'POST';
     config.headers = config.headers || {};
     config.headers['X-HTTP-Method-Override'] = 'GET';
+    config.headers['Content-Type'] = config.headers['Content-Type'] || 'application/x-www-form-urlencoded';
     config.url = this.getUrl(config);
     config.data = data;
     if (this.beforePostGet) {
       config.data = this.beforePostGet(config.data);
+    }
+    if (typeof config.data !== 'string' && config.headers['Content-Type'] === 'application/x-www-form-urlencoded') {
+      config.data = qs.stringify(config.data, {
+        encode: false,
+        arrayFormat: 'repeat',
+        indices: false,
+        allowDots: true,
+      });
     }
     return this.request(config, this.afterPostGet);
   }

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -766,10 +766,11 @@ describe('AvApi', () => {
           url: testUrl,
           headers: {
             'X-HTTP-Method-Override': 'GET',
+            'Content-Type': 'application/x-www-form-urlencoded',
           },
         },
         config,
-        { data }
+        { data: 'testData=data' }
       );
       api.postGet(data, config);
       expect(api.getUrl).toHaveBeenLastCalledWith(expectedConfig);
@@ -789,10 +790,11 @@ describe('AvApi', () => {
           url: testUrl,
           headers: {
             'X-HTTP-Method-Override': 'GET',
+            'Content-Type': 'application/x-www-form-urlencoded',
           },
         },
         config,
-        { data }
+        { data: 'testData=data' }
       );
       api.beforePostGet = jest.fn(thisData => thisData);
       api.postGet(data, config);


### PR DESCRIPTION
Currently postGet will *not* send data as `application/x-www-form-urlencoded` nor will it format the data to `application/x-www-form-urlencoded`. Availity's API's require the data to be sent as `application/x-www-form-urlencoded` with the `Content-Type` header as `application/x-www-form-urlencoded`. This change sets the default way `postGet` works to do just that.