### PR TITLE
test(localstorage-core): implement tests with jsdom's localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "transformIgnorePatterns": [
       "<rootDir>.*(node_modules)(?!.*@availity.*).*$"
     ],
-    "testEnvironment": "jest-environment-jsdom-global"
+    "testEnvironment": "jest-environment-jsdom-global",
+    "testURL": "http://localhost/"
   },
   "babel": {
     "env": {

--- a/packages/localstorage-core/src/index.js
+++ b/packages/localstorage-core/src/index.js
@@ -40,7 +40,7 @@ class AvLocalStorage {
       return output;
     }
 
-    return undefined;
+    return null;
   }
 
   set(key, value) {


### PR DESCRIPTION
Some of the tests are not really possible as you cannot replace nor spy on localStorage so those tests needed to be removed.