### PR TITLE
fix(api-core): return error from async/await

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "dependencies": {
+    "lodash.get": "^4.4.2",
     "qs": "^6.5.2"
   }
 }

--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -162,7 +162,7 @@ export default class AvApi {
 
   getError(error) {
     const response = {};
-    response.errorObject = error;
+    response.original = error;
     response.code = get(error, 'response.status');
     response.message = get(error, 'response.statusText');
     response.url = get(error, 'config.url');

--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -1,5 +1,6 @@
 import AvLocalStorage from '@availity/localstorage-core';
 import qs from 'qs';
+import get from 'lodash.get';
 
 import API_OPTIONS from './options';
 
@@ -160,10 +161,11 @@ export default class AvApi {
   }
 
   getError(error) {
-    let response;
-    if (error.response) {
-      response = { error };
-    }
+    const response = {};
+    response.errorObject = error;
+    response.code = get(error, 'response.status');
+    response.message = get(error, 'response.statusText');
+    response.url = get(error, 'config.url');
     return response;
   }
 
@@ -176,10 +178,7 @@ export default class AvApi {
 
     return this.http(config)
       .then(response => this.onResponse(response, afterResponse))
-      .catch(error => {
-        const response = this.getError(error);
-        return afterResponse ? afterResponse(response) : response;
-      });
+      .catch(error => this.Promise.reject(this.getError(error)));
   }
 
   // post request

--- a/packages/api-core/src/ms.js
+++ b/packages/api-core/src/ms.js
@@ -25,15 +25,6 @@ export default class AvMicroservice extends AvApi {
       .replace(/\/$/, '');
   }
 
-  getError(error) {
-    let response;
-    if (error) {
-      response = error;
-      response.error = true;
-    }
-    return response;
-  }
-
   // polling location is the same url
   getLocation(response) {
     return this.getUrl(response.config);

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -662,12 +662,6 @@ describe('AvApi', () => {
       expect(mockHttp).toHaveBeenCalledWith(mockConfig);
     });
 
-    test('should catch error in http, returning undefined if no error.response', async () => {
-      mockHttp.mockImplementationOnce(() => Promise.reject(new Error('err')));
-      const response = await api.request({});
-      expect(response).toBeUndefined();
-    });
-
     test('should default attempt in polling is true', async () => {
       const mockConfig = {
         polling: true,
@@ -680,6 +674,35 @@ describe('AvApi', () => {
       const response = await api.request(mockConfig);
       expect(mockHttp).toHaveBeenCalledWith(expectedConfig);
       expect(response).toEqual(mockFinalResponse);
+    });
+  });
+
+  describe('request error', () => {
+    const mockErrorResponse = {
+      response: { status: 500, statusText: 'Test Error' },
+      config: { url: '/url' },
+    };
+
+    beforeEach(() => {
+      api = new AvApi({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        config: {},
+      });
+      api.onResponse = jest.fn(() => api.getError(mockErrorResponse));
+    });
+    test('should catch error in http, and return that error', async () => {
+      const response = await api.request({});
+      expect(response.errorObject).toBe(mockErrorResponse);
+    });
+
+    test('should return error format', async () => {
+      const response = await api.request({});
+      expect(response.code).toBe(500);
+      expect(response.message).toBe('Test Error');
+      expect(response.url).toBe('/url');
+      expect(response.errorObject).toBe(mockErrorResponse);
     });
   });
 

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -694,7 +694,7 @@ describe('AvApi', () => {
     });
     test('should catch error in http, and return that error', async () => {
       const response = await api.request({});
-      expect(response.errorObject).toBe(mockErrorResponse);
+      expect(response.original).toBe(mockErrorResponse);
     });
 
     test('should return error format', async () => {
@@ -702,7 +702,7 @@ describe('AvApi', () => {
       expect(response.code).toBe(500);
       expect(response.message).toBe('Test Error');
       expect(response.url).toBe('/url');
-      expect(response.errorObject).toBe(mockErrorResponse);
+      expect(response.original).toBe(mockErrorResponse);
     });
   });
 

--- a/packages/api-core/src/tests/ms.test.js
+++ b/packages/api-core/src/tests/ms.test.js
@@ -81,6 +81,7 @@ describe('AvMicroservice', () => {
   });
 
   describe('getUrl', () => {
+    const mockFinalResponse = 'finalResponse';
     beforeEach(() => {
       ms = new AvMicroservice({
         http: mockHttp,
@@ -88,6 +89,7 @@ describe('AvMicroservice', () => {
         merge: mockMerge,
         config: {},
       });
+      ms.onResponse = jest.fn(() => mockFinalResponse);
     });
 
     test('should return joined config.path and name if no config.id', () => {
@@ -110,7 +112,7 @@ describe('AvMicroservice', () => {
       }).toThrow('called method without [id]');
     });
 
-    test('get() should build url wih id', async () => {
+    test('get() should build url with id', async () => {
       await ms.get(1);
 
       expect(mockHttp.mock.calls[0][0].url).toBe('/ms/api/availity/internal/1');


### PR DESCRIPTION
BREAKING CHANGE: return the error from the async/await call up the chain so it can be caught in a try/catch