### PR TITLE
fix(api-core): http should throw errors

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -23,7 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "lodash.get": "^4.4.2",
     "qs": "^6.5.2"
   }
 }

--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -1,6 +1,5 @@
 import AvLocalStorage from '@availity/localstorage-core';
 import qs from 'qs';
-import get from 'lodash.get';
 
 import API_OPTIONS from './options';
 
@@ -160,15 +159,6 @@ export default class AvApi {
     return afterResponse ? afterResponse(response) : response;
   }
 
-  getError(error) {
-    const response = {};
-    response.original = error;
-    response.code = get(error, 'response.status');
-    response.message = get(error, 'response.statusText');
-    response.url = get(error, 'config.url');
-    return response;
-  }
-
   // make request to http
   request(config, afterResponse) {
     if (config.polling) {
@@ -176,9 +166,9 @@ export default class AvApi {
       config.attempt += 1;
     }
 
-    return this.http(config)
-      .then(response => this.onResponse(response, afterResponse))
-      .catch(error => this.Promise.reject(this.getError(error)));
+    return this.http(config).then(response =>
+      this.onResponse(response, afterResponse)
+    );
   }
 
   // post request

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -678,11 +678,6 @@ describe('AvApi', () => {
   });
 
   describe('request error', () => {
-    const mockErrorResponse = {
-      response: { status: 500, statusText: 'Test Error' },
-      config: { url: '/url' },
-    };
-
     beforeEach(() => {
       api = new AvApi({
         http: mockHttp,
@@ -690,19 +685,12 @@ describe('AvApi', () => {
         merge: mockMerge,
         config: {},
       });
-      api.onResponse = jest.fn(() => api.getError(mockErrorResponse));
+      api.onResponse = jest.fn(() => {
+        throw new Error('boom!');
+      });
     });
-    test('should catch error in http, and return that error', async () => {
-      const response = await api.request({});
-      expect(response.original).toBe(mockErrorResponse);
-    });
-
-    test('should return error format', async () => {
-      const response = await api.request({});
-      expect(response.code).toBe(500);
-      expect(response.message).toBe('Test Error');
-      expect(response.url).toBe('/url');
-      expect(response.original).toBe(mockErrorResponse);
+    test('should throw error', async () => {
+      await expect(api.request({})).rejects.toThrow();
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: The http error is no longer caught by api-core. Also, the error object is no longer manipulated. Developers must handle the http error by catching the error when using async/await or by leveraging the error callback in the promise chain. The callback `afterResponse` is not called when and error is thrown from http call.