### PR TITLE
refactor: independent publishing and dev deps upgrades

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@
 -   [api-angular](packages/api-angular/README.md) - A package wrapping [@av/api-core](../api-core/README.md) with Angular `$http`.
 -   [localalstorage-core](packages/localstorage-core/README.md) - Wraps localStorage with utility functions.
 -   [message-core](packages/message-core/README.md) - Wraps postMessage function with helper functions and security checks.
--   [upload-core](packages/upload-core/README.md) - > Wrapper for tus-js-client
--   [dl-core](packages/dl-core/README.md) - > Wrapper for js-file-download
+- [upload-core](packages/upload-core/README.md) - > Wrapper for tus-js-client
+- [dl-core](packages/dl-core/README.md) - > Wrapper for js-file-download
 
 ## Contribute
 
--   Run `npm install`
--   Commits should use the [Angular Commit Format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type). Scope should one of packages under `./packages/`. If a commit applys to multiple packages, leave out the scope.
--   Release versions with Semantic version and `npm run release`. The version is determined by analyzing the commit messaging. To use a custom version, run `npm run release <VERSION>`.
+- Run `npm install`
+- Commits should use the [Angular Commit Format](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type). Scope should one of packages under `./packages/`. If a commit applys to multiple packages, leave out the scope.
+- Release versions with Semantic version and `npm run release`. The version is determined by analyzing the commit messaging. To use a custom version, run `npm run release <VERSION>`.
 
 ## License
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+  testEnvironment: 'jest-environment-jsdom-global',
+  testURL: 'http://localhost/',
+};
+
+module.exports = api => {
+  api.cache(true);
+
+  return {
+    presets: [
+      [
+        '@babel/env',
+        {
+          targets: {
+            browsers: 'Last 2 Chrome versions, Firefox ESR',
+            node: 'current',
+          },
+        },
+      ],
+      '@babel/preset-react',
+    ],
+    plugins: [
+      '@babel/plugin-proposal-object-rest-spread',
+      '@babel/plugin-transform-destructuring',
+      '@babel/plugin-syntax-dynamic-import',
+      '@babel/plugin-transform-object-assign',
+      '@babel/plugin-transform-regenerator',
+      '@babel/plugin-transform-runtime',
+      '@babel/plugin-transform-shorthand-properties',
+      '@babel/plugin-proposal-class-properties',
+    ],
+    ignore: ['node_modules'],
+  };
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testPathIgnorePatterns: ['<rootDir>.*(node_modules)(?!.*@availity.*).*$'],
+  testEnvironment: 'jest-environment-jsdom-global',
+  testURL: 'http://localhost',
+  globals: {
+    jsdom: true,
+  },
+};

--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,13 @@
 {
   "lerna": "2.5.1",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "message": "chore: publish %s",
   "command": {
     "publish": {
-      "allowBranch": "master",
+      "allowBranch": ["master", "feature/*"],
       "conventionalCommits": true
     }
   },
+  "ignoreChanges": ["**/*.test.js", "**/*.md", "**/package-lock.json"],
   "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -6,57 +6,54 @@
     "url": "https://github.com/Availity/sdk-js.git"
   },
   "scripts": {
-    "format": "prettier --write 'packages/*/*.js' 'packages/*/!(node_modules)/**/*.js'",
     "lint": "eslint .",
     "bootstrap": "lerna bootstrap",
     "link": "lerna link",
     "updated": "lerna updated",
-    "clean": "lerna clean",
-    "precommit": "lint-staged",
+    "clean": "lerna clean --yes",
+    "publish-canary": "lerna version prerelease --preid canary --force-publish && release --pre",
     "publish": "lerna publish",
     "test": "jest --silent",
     "postinstall": "npm run bootstrap",
-    "release": "sh ./scripts/release.sh",
-    "commitmsg": "commitlint -e $GIT_PARAMS",
+    "release": "lerna publish",
+    "release:canary": "lerna publish -c",
     "add": "sh ./scripts/add.sh",
     "remove-locks": "find . -type f -name 'package-lock.json' -delete"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-decorators": "^7.0.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+    "@babel/plugin-transform-destructuring": "^7.0.0",
+    "@babel/plugin-syntax-dynamic-import": "7.0.0",
+    "@babel/plugin-transform-object-assign": "^7.0.0",
+    "@babel/plugin-transform-regenerator": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.0.0",
+    "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.1",
     "@commitlint/config-lerna-scopes": "^7.0.0",
-    "babel-core": "^6.26.3",
-    "babel-eslint": "^8.2.5",
-    "babel-jest": "^23.2.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-stage-0": "^6.24.1",
-    "conventional-changelog-cli": "^1.3.5",
-    "conventional-recommended-bump": "^2.0.8",
-    "eslint": "^4.13.1",
-    "eslint-config-airbnb": "^16.1.0",
-    "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-config-availity": "^3.0.0-beta.11",
-    "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-react": "^7.10.0",
-    "husky": "^0.14.3",
-    "jest": "^23.2.0",
+    "babel-eslint": "^10.0.1",
+    "babel-jest": "^23.4.2",
+    "conventional-changelog-cli": "^2.0.11",
+    "conventional-recommended-bump": "^4.0.4",
+    "eslint-config-availity": "^4.0.1",
+    "husky": "^1.3.1",
+    "jest": "^24.1.0",
     "jest-environment-jsdom-global": "^1.1.0",
-    "lerna": "^2.11.0",
-    "lint-staged": "^7.2.0",
-    "prettier": "^1.13.7",
-    "regenerator-runtime": "^0.12.0"
+    "lerna": "^3.11.0",
+    "lint-staged": "^8.1.3",
+    "prettier": "^1.13.7"
   },
   "license": "MIT",
   "lint-staged": {
     "*.js": [
       "eslint --fix",
       "prettier --write",
+      "npm test",
       "git add"
     ]
   },
@@ -77,39 +74,6 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>.*(node_modules)(?!.*@availity.*).*$"
-    ],
-    "testEnvironment": "jest-environment-jsdom-global",
-    "testURL": "http://localhost/"
-  },
-  "babel": {
-    "env": {
-      "test": {
-        "plugins": [
-          "transform-class-properties",
-          "transform-object-rest-spread"
-        ],
-        "presets": [
-          "jest",
-          "react",
-          "stage-0",
-          [
-            "env",
-            {
-              "debug": false,
-              "modules": "commonjs",
-              "targets": {
-                "node": "current"
-              },
-              "useBuiltIns": true
-            }
-          ]
-        ]
-      }
-    }
-  },
   "contributors": [
     {
       "name": "kasey powers",
@@ -120,5 +84,10 @@
       "url": "https://github.com/robmcguinness"
     }
   ],
-  "version": "2.10.0"
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
+      "pre-commit": "lint-staged"
+    }
+  }
 }

--- a/packages/analytics-angular/package-lock.json
+++ b/packages/analytics-angular/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "@availity/analytics-angular",
+	"version": "2.6.2",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"angular": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular/-/angular-1.7.3.tgz",
-			"integrity": "sha512-hQRhU56shs72y88cS0Uy9g+UAMHoztJ3V+r+iF8o1AK/Bpu8ewmjFDk9j2LjSuN05a9mhxW1rOHnYKOwyTS/Zg=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular/-/angular-1.7.7.tgz",
+			"integrity": "sha1-Jr2HaT3q3L1ZRGEKegRj/HmhiAM=",
+			"dev": true
 		},
 		"angular-mocks": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.7.3.tgz",
-			"integrity": "sha512-j9JZxJiTdwr1oZPtQQFSMpfNZiY+LzKJaodVeWCdXMA1+mOXxS2f8k0yEnG618O2LHd/MU8z3IibyVgbl9xuiA=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular-mocks/-/angular-mocks-1.7.7.tgz",
+			"integrity": "sha1-In/sqKfpzGHEaANm2wJNZWPUxus=",
+			"dev": true
 		}
 	}
 }

--- a/packages/analytics-angular/src/analytics.js
+++ b/packages/analytics-angular/src/analytics.js
@@ -8,19 +8,21 @@ export default class AvAnalyticsProvider {
 
     this.$get.$inject = ['$log', '$injector', '$q', '$rootScope'];
   }
+
   registerPlugins(plugins) {
     if (typeof plugins === 'string') {
       this.plugins = [plugins];
     } else if (Array.isArray(plugins)) {
       this.plugins = plugins;
     } else {
-      throw new Error(
+      throw new TypeError(
         'AvAnalyticsProvider.registerPlugins() expects a string or an array.'
       );
     }
   }
+
   setVirtualPageTracking(value) {
-    if (arguments.length) {
+    if (arguments.length > 0) {
       this.virtualPageTracking = !!value;
     }
   }
@@ -39,7 +41,7 @@ export default class AvAnalyticsProvider {
           if (typeof plugin === 'string') {
             try {
               plugins.push($injector.get(plugin));
-            } catch (err) {
+            } catch (error) {
               $log.error(`Could not load ${plugin} plugin`);
             }
           } else {

--- a/packages/analytics-angular/src/tests/analytics.test.js
+++ b/packages/analytics-angular/src/tests/analytics.test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import AvModule from '../';
+import AvModule from '..';
 
 describe('AvAnalyticsProvider', () => {
   let provider;

--- a/packages/analytics-angular/src/tests/plugin.test.js
+++ b/packages/analytics-angular/src/tests/plugin.test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import AvModule from '../';
+import AvModule from '..';
 
 describe('AvAnalyticsPlugin', () => {
   // let $q;

--- a/packages/analytics-angular/src/tests/splunk.test.js
+++ b/packages/analytics-angular/src/tests/splunk.test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import AvModule from '../';
+import AvModule from '..';
 
 describe('AvSplunkAnalytics', () => {
   let AvSplunkAnalytics;

--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -72,7 +72,7 @@ export default class AvAnalytics {
     const target = event.target || event.srcElement;
     const analyticAttrs = getAnalyticAttrs(target);
 
-    if (!Object.keys(analyticAttrs).length) {
+    if (!Object.keys(analyticAttrs).length > 0) {
       return;
     }
     analyticAttrs.elemId =
@@ -108,7 +108,7 @@ export default class AvAnalytics {
   }
 
   setPageTracking(value) {
-    if (arguments.length) {
+    if (arguments.length > 0) {
       this.pageTracking = !!value;
     }
 

--- a/packages/analytics-core/src/tests/analytics.test.js
+++ b/packages/analytics-core/src/tests/analytics.test.js
@@ -1,4 +1,4 @@
-import { AvAnalytics } from '../';
+import { AvAnalytics } from '..';
 
 function makePlugin() {
   return {

--- a/packages/analytics-core/src/tests/plugin.test.js
+++ b/packages/analytics-core/src/tests/plugin.test.js
@@ -1,4 +1,4 @@
-import { AvAnalyticsPlugin } from '../';
+import { AvAnalyticsPlugin } from '..';
 
 describe('AvAnalyticsPlugin', () => {
   let mockPlugin;

--- a/packages/analytics-core/src/tests/splunk.test.js
+++ b/packages/analytics-core/src/tests/splunk.test.js
@@ -1,4 +1,4 @@
-import { AvSplunkAnalytics } from '../';
+import { AvSplunkAnalytics } from '..';
 
 describe('AvSplunkAnalytics', () => {
   let mockLog;

--- a/packages/api-angular/package-lock.json
+++ b/packages/api-angular/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "@availity/api-angular",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"angular": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular/-/angular-1.7.3.tgz",
-			"integrity": "sha512-hQRhU56shs72y88cS0Uy9g+UAMHoztJ3V+r+iF8o1AK/Bpu8ewmjFDk9j2LjSuN05a9mhxW1rOHnYKOwyTS/Zg=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular/-/angular-1.7.7.tgz",
+			"integrity": "sha1-Jr2HaT3q3L1ZRGEKegRj/HmhiAM=",
+			"dev": true
 		},
 		"angular-mocks": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.7.3.tgz",
-			"integrity": "sha512-j9JZxJiTdwr1oZPtQQFSMpfNZiY+LzKJaodVeWCdXMA1+mOXxS2f8k0yEnG618O2LHd/MU8z3IibyVgbl9xuiA=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular-mocks/-/angular-mocks-1.7.7.tgz",
+			"integrity": "sha1-In/sqKfpzGHEaANm2wJNZWPUxus=",
+			"dev": true
 		}
 	}
 }

--- a/packages/api-angular/src/options.js
+++ b/packages/api-angular/src/options.js
@@ -8,9 +8,11 @@ class AvApiOptionsProvider {
       },
     };
   }
+
   setOptions(options) {
     angular.merge(this.defaultOptions, options);
   }
+
   getOptions() {
     return angular.copy(this.defaultOptions);
   }

--- a/packages/api-angular/src/tests/api.test.js
+++ b/packages/api-angular/src/tests/api.test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import avModule from '../';
+import avModule from '..';
 
 describe('Api Definitions Angular', () => {
   beforeEach(() => {

--- a/packages/api-angular/src/tests/module.test.js
+++ b/packages/api-angular/src/tests/module.test.js
@@ -1,4 +1,4 @@
-import avModule from '../';
+import avModule from '..';
 
 describe('api module', () => {
   test('should be defined', () => {

--- a/packages/api-angular/src/tests/ms.test.js
+++ b/packages/api-angular/src/tests/ms.test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import avModule from '../';
+import avModule from '..';
 
 describe('MicroserviceApi Definitions Angular', () => {
   beforeEach(() => {
@@ -13,7 +13,7 @@ describe('MicroserviceApi Definitions Angular', () => {
         const AvMicroserviceApi = _AvMicroserviceApi_;
         expect(AvMicroserviceApi).toBeDefined();
         expect(() => {
-          // eslint-disable-next-line
+          // eslint-disable-next-line no-new
           new AvMicroserviceApi({ path: '/a/b', name: 'foo' });
         }).not.toThrow();
 

--- a/packages/api-angular/src/tests/options.test.js
+++ b/packages/api-angular/src/tests/options.test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import avApiModule from '../';
+import avApiModule from '..';
 
 describe('avApiOptionsProvider', () => {
   let provider;

--- a/packages/api-axios/package-lock.json
+++ b/packages/api-axios/package-lock.json
@@ -1,21 +1,23 @@
 {
-	"requires": true,
+	"name": "@availity/api-axios",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"ansi-regex": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
 		"anymatch": {
 			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
 			"optional": true,
 			"requires": {
 				"micromatch": "^2.1.5",
@@ -24,7 +26,7 @@
 		},
 		"arr-diff": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"optional": true,
 			"requires": {
@@ -33,40 +35,45 @@
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+			"optional": true
 		},
 		"arr-union": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"optional": true
 		},
 		"array-unique": {
 			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/array-unique/-/array-unique-0.2.1.tgz",
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 			"optional": true
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"optional": true
 		},
 		"async-each": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/async-each/-/async-each-1.0.1.tgz",
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
 			"optional": true
 		},
 		"atob": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+			"optional": true
 		},
 		"axios": {
 			"version": "0.17.1",
-			"resolved": "http://repo.availity.com:8081/artifactory/api/npm/npm/axios/-/axios-0.17.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/axios/-/axios-0.17.1.tgz",
 			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"dev": true,
 			"requires": {
 				"follow-redirects": "^1.2.5",
 				"is-buffer": "^1.1.5"
@@ -74,7 +81,7 @@
 		},
 		"babel-cli": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-cli/-/babel-cli-6.26.0.tgz",
 			"integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
 			"requires": {
 				"babel-core": "^6.26.0",
@@ -96,7 +103,7 @@
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
 				"chalk": "^1.1.3",
@@ -106,8 +113,8 @@
 		},
 		"babel-core": {
 			"version": "6.26.3",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
 			"requires": {
 				"babel-code-frame": "^6.26.0",
 				"babel-generator": "^6.26.0",
@@ -128,22 +135,12 @@
 				"private": "^0.1.8",
 				"slash": "^1.0.0",
 				"source-map": "^0.5.7"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"babel-generator": {
 			"version": "6.26.1",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
 			"requires": {
 				"babel-messages": "^6.23.0",
 				"babel-runtime": "^6.26.0",
@@ -157,7 +154,7 @@
 		},
 		"babel-helpers": {
 			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
 				"babel-runtime": "^6.22.0",
@@ -166,7 +163,7 @@
 		},
 		"babel-messages": {
 			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
 				"babel-runtime": "^6.22.0"
@@ -174,7 +171,7 @@
 		},
 		"babel-polyfill": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"requires": {
 				"babel-runtime": "^6.26.0",
@@ -184,14 +181,14 @@
 			"dependencies": {
 				"regenerator-runtime": {
 					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
 					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
 				}
 			}
 		},
 		"babel-register": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
 				"babel-core": "^6.26.0",
@@ -205,7 +202,7 @@
 		},
 		"babel-runtime": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
 				"core-js": "^2.4.0",
@@ -214,7 +211,7 @@
 		},
 		"babel-template": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
 				"babel-runtime": "^6.26.0",
@@ -226,7 +223,7 @@
 		},
 		"babel-traverse": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
 				"babel-code-frame": "^6.26.0",
@@ -238,21 +235,11 @@
 				"globals": "^9.18.0",
 				"invariant": "^2.2.2",
 				"lodash": "^4.17.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
 			}
 		},
 		"babel-types": {
 			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
 				"babel-runtime": "^6.26.0",
@@ -263,18 +250,19 @@
 		},
 		"babylon": {
 			"version": "6.18.0",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/base/-/base-0.11.2.tgz",
+			"integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+			"optional": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -287,32 +275,36 @@
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"optional": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -321,26 +313,28 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+					"optional": true
 				}
 			}
 		},
 		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+			"version": "1.13.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/binary-extensions/-/binary-extensions-1.13.0.tgz",
+			"integrity": "sha1-lSPgATBqMkRLkHQj8d4hZCIvarE=",
 			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -348,7 +342,7 @@
 		},
 		"braces": {
 			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"optional": true,
 			"requires": {
@@ -359,8 +353,9 @@
 		},
 		"cache-base": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+			"optional": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -375,14 +370,15 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"chalk": {
 			"version": "1.1.3",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
 				"ansi-styles": "^2.2.1",
@@ -394,7 +390,7 @@
 		},
 		"chokidar": {
 			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/chokidar/-/chokidar-1.7.0.tgz",
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"optional": true,
 			"requires": {
@@ -411,8 +407,9 @@
 		},
 		"class-utils": {
 			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+			"optional": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -422,84 +419,91 @@
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"collection-visit": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"optional": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
-			"integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
+			"version": "2.19.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So="
 		},
 		"component-emitter": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"optional": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"convert-source-map": {
 			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"optional": true
 		},
 		"core-js": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+			"version": "2.6.4",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/core-js/-/core-js-2.6.4.tgz",
+			"integrity": "sha1-uIl8BixNdp3TCgrFxzl2xH+S6g0="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"optional": true
 		},
 		"debug": {
-			"version": "3.1.0",
-			"resolved": "http://repo.availity.com:8081/artifactory/api/npm/npm/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+			"version": "2.6.9",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
 			"requires": {
 				"ms": "2.0.0"
 			}
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"optional": true
 		},
 		"define-property": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+			"optional": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -507,24 +511,27 @@
 			"dependencies": {
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -533,19 +540,21 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+					"optional": true
 				}
 			}
 		},
 		"detect-indent": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"requires": {
 				"repeating": "^2.0.0"
@@ -553,17 +562,17 @@
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"esutils": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/esutils/-/esutils-2.0.2.tgz",
 			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"optional": true,
 			"requires": {
@@ -572,7 +581,7 @@
 		},
 		"expand-range": {
 			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"optional": true,
 			"requires": {
@@ -581,8 +590,9 @@
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"optional": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -590,8 +600,9 @@
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+					"optional": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -600,7 +611,7 @@
 		},
 		"extglob": {
 			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"optional": true,
 			"requires": {
@@ -609,14 +620,14 @@
 		},
 		"filename-regex": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/filename-regex/-/filename-regex-2.0.1.tgz",
 			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
 			"optional": true
 		},
 		"fill-range": {
 			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
 			"optional": true,
 			"requires": {
 				"is-number": "^2.1.0",
@@ -627,21 +638,34 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.4.1",
-			"resolved": "http://repo.availity.com:8081/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.4.1.tgz",
-			"integrity": "sha1-2BIPRRgZD1Wqxlu2/HuF/NZm1qo=",
+			"version": "1.6.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.6.1.tgz",
+			"integrity": "sha1-UUlzxEtXVzaLrYvd/lL4HwFclMs=",
+			"dev": true,
 			"requires": {
-				"debug": "^3.1.0"
+				"debug": "=3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
 			}
 		},
 		"for-in": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"optional": true
 		},
 		"for-own": {
 			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"optional": true,
 			"requires": {
@@ -650,26 +674,27 @@
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"optional": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
 		},
 		"fs-readdir-recursive": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+			"integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha1-SFG2ZKN4PlIAOzxm6w7uEHSTOqQ=",
 			"optional": true,
 			"requires": {
 				"nan": "^2.9.2",
@@ -683,7 +708,8 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -691,7 +717,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -701,32 +727,37 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -742,7 +773,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -785,7 +816,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -803,11 +834,11 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -829,7 +860,8 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -839,6 +871,7 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -851,24 +884,27 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -878,6 +914,7 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -888,7 +925,7 @@
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -898,17 +935,17 @@
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -924,12 +961,12 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -950,7 +987,8 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -960,6 +998,7 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -994,11 +1033,11 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -1026,16 +1065,17 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
-					"bundled": true
+					"version": "5.1.2",
+					"bundled": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -1048,7 +1088,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"optional": true
 				},
@@ -1065,6 +1105,7 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -1082,6 +1123,7 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -1092,16 +1134,16 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -1111,32 +1153,35 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true
+					"bundled": true,
+					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
-					"bundled": true
+					"version": "3.0.3",
+					"bundled": true,
+					"optional": true
 				}
 			}
 		},
 		"get-value": {
 			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"optional": true
 		},
 		"glob": {
 			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1148,7 +1193,7 @@
 		},
 		"glob-base": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"optional": true,
 			"requires": {
@@ -1158,25 +1203,26 @@
 		},
 		"glob-parent": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"optional": true,
 			"requires": {
 				"is-glob": "^2.0.0"
 			}
 		},
 		"globals": {
 			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
 		},
 		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+			"version": "4.1.15",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha1-/7cD4QZuig7qpMi4C6klPu77+wA="
 		},
 		"has-ansi": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -1184,8 +1230,9 @@
 		},
 		"has-value": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"optional": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -1194,15 +1241,17 @@
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"has-values": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"optional": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -1210,16 +1259,18 @@
 			"dependencies": {
 				"is-number": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"optional": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -1228,8 +1279,9 @@
 				},
 				"kind-of": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -1238,7 +1290,7 @@
 		},
 		"home-or-tmp": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"requires": {
 				"os-homedir": "^1.0.0",
@@ -1247,7 +1299,7 @@
 		},
 		"inflight": {
 			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
 				"once": "^1.3.0",
@@ -1256,28 +1308,29 @@
 		},
 		"inherits": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"invariant": {
 			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"optional": true,
 			"requires": {
@@ -1286,21 +1339,23 @@
 		},
 		"is-buffer": {
 			"version": "1.1.6",
-			"resolved": "http://repo.availity.com:8081/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
 		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+			"optional": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -1309,20 +1364,21 @@
 			"dependencies": {
 				"kind-of": {
 					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+					"optional": true
 				}
 			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
 			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
 			"optional": true
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"optional": true,
 			"requires": {
@@ -1331,17 +1387,19 @@
 		},
 		"is-extendable": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"optional": true
 		},
 		"is-extglob": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"optional": true
 		},
 		"is-finite": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
 				"number-is-nan": "^1.0.0"
@@ -1349,15 +1407,16 @@
 		},
 		"is-glob": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"optional": true,
 			"requires": {
 				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-number": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"optional": true,
 			"requires": {
@@ -1366,50 +1425,53 @@
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
 			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+			"optional": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"is-posix-bracket": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
 			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
 			"optional": true
 		},
 		"is-primitive": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-primitive/-/is-primitive-2.0.0.tgz",
 			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
 			"optional": true
 		},
 		"is-windows": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
 			"optional": true
 		},
 		"isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"optional": true
 		},
 		"isobject": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
 			"optional": true,
 			"requires": {
@@ -1418,63 +1480,66 @@
 		},
 		"js-tokens": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/js-tokens/-/js-tokens-3.0.2.tgz",
 			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
 		},
 		"jsesc": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/jsesc/-/jsesc-1.3.0.tgz",
 			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
 		},
 		"json5": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/json5/-/json5-0.5.1.tgz",
 			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
 		},
 		"kind-of": {
 			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"optional": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
 			}
 		},
 		"lodash": {
 			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
 		},
 		"map-cache": {
 			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"optional": true
 		},
 		"map-visit": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"optional": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
 		},
 		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+			"version": "1.0.4",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
 			"optional": true
 		},
 		"merge-options-es5": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/merge-options-es5/-/merge-options-es5-1.0.0.tgz",
-			"integrity": "sha512-8uRqnY/uIN1SeeoWUc/PyltdYKVX57goIhipWJO31kasIXsUuwN3va5iMa9MjXWq3nOwH/cdC9dzTOf9xNnmWw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/merge-options-es5/-/merge-options-es5-1.0.0.tgz",
+			"integrity": "sha1-ahbsamFCgR5Q9ZrTOJkzBv2KUgQ=",
 			"requires": {
 				"babel-cli": "^6.26.0",
 				"is-plain-obj": "^1.1"
@@ -1482,7 +1547,7 @@
 		},
 		"micromatch": {
 			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"optional": true,
 			"requires": {
@@ -1503,21 +1568,22 @@
 		},
 		"minimatch": {
 			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
 			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
+			"optional": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -1525,8 +1591,9 @@
 			"dependencies": {
 				"is-extendable": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+					"optional": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -1535,7 +1602,7 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
@@ -1543,19 +1610,19 @@
 		},
 		"ms": {
 			"version": "2.0.0",
-			"resolved": "http://repo.availity.com:8081/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"nan": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-			"integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+			"version": "2.12.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/nan/-/nan-2.12.1.tgz",
+			"integrity": "sha1-exqhk+mqhgV+PHu9CsRI53CSVVI=",
 			"optional": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
 			"optional": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
@@ -1573,46 +1640,48 @@
 			"dependencies": {
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"optional": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
 					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"optional": true
 				}
 			}
 		},
 		"normalize-path": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"optional": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"number-is-nan": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"object-assign": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"optional": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -1621,8 +1690,9 @@
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -1631,22 +1701,24 @@
 		},
 		"object-visit": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"optional": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"object.omit": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"optional": true,
 			"requires": {
@@ -1656,22 +1728,24 @@
 		},
 		"object.pick": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"optional": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"once": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
 				"wrappy": "1"
@@ -1679,17 +1753,17 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"output-file-sync": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"requires": {
 				"graceful-fs": "^4.1.4",
@@ -1699,7 +1773,7 @@
 		},
 		"parse-glob": {
 			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"optional": true,
 			"requires": {
@@ -1711,41 +1785,42 @@
 		},
 		"pascalcase": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"optional": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"posix-character-classes": {
 			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"optional": true
 		},
 		"preserve": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/preserve/-/preserve-0.2.0.tgz",
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
 			"optional": true
 		},
 		"private": {
 			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/private/-/private-0.1.8.tgz",
+			"integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8="
 		},
 		"process-nextick-args": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
 			"optional": true
 		},
 		"randomatic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-			"integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+			"version": "3.1.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
 			"optional": true,
 			"requires": {
 				"is-number": "^4.0.0",
@@ -1755,22 +1830,22 @@
 			"dependencies": {
 				"is-number": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
 					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
 					"optional": true
 				}
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
 			"optional": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
@@ -1784,8 +1859,8 @@
 		},
 		"readdirp": {
 			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
 			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
@@ -1795,19 +1870,20 @@
 			"dependencies": {
 				"arr-diff": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/arr-diff/-/arr-diff-4.0.0.tgz",
 					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
 					"optional": true
 				},
 				"array-unique": {
 					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"optional": true
 				},
 				"braces": {
 					"version": "2.3.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
 					"optional": true,
 					"requires": {
 						"arr-flatten": "^1.1.0",
@@ -1824,7 +1900,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"optional": true,
 							"requires": {
@@ -1833,18 +1909,9 @@
 						}
 					}
 				},
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
 				"expand-brackets": {
 					"version": "2.1.4",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"optional": true,
 					"requires": {
@@ -1859,7 +1926,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "0.2.5",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"optional": true,
 							"requires": {
@@ -1868,7 +1935,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"optional": true,
 							"requires": {
@@ -1877,7 +1944,7 @@
 						},
 						"is-accessor-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"optional": true,
 							"requires": {
@@ -1886,7 +1953,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"optional": true,
 									"requires": {
@@ -1897,7 +1964,7 @@
 						},
 						"is-data-descriptor": {
 							"version": "0.1.4",
-							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"optional": true,
 							"requires": {
@@ -1906,7 +1973,7 @@
 							"dependencies": {
 								"kind-of": {
 									"version": "3.2.2",
-									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"optional": true,
 									"requires": {
@@ -1917,8 +1984,8 @@
 						},
 						"is-descriptor": {
 							"version": "0.1.6",
-							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
 							"optional": true,
 							"requires": {
 								"is-accessor-descriptor": "^0.1.6",
@@ -1928,16 +1995,16 @@
 						},
 						"kind-of": {
 							"version": "5.1.0",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
 							"optional": true
 						}
 					}
 				},
 				"extglob": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
 					"optional": true,
 					"requires": {
 						"array-unique": "^0.3.2",
@@ -1952,7 +2019,7 @@
 					"dependencies": {
 						"define-property": {
 							"version": "1.0.0",
-							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"optional": true,
 							"requires": {
@@ -1961,7 +2028,7 @@
 						},
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"optional": true,
 							"requires": {
@@ -1972,7 +2039,7 @@
 				},
 				"fill-range": {
 					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"optional": true,
 					"requires": {
@@ -1984,7 +2051,7 @@
 					"dependencies": {
 						"extend-shallow": {
 							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"optional": true,
 							"requires": {
@@ -1995,8 +2062,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2004,8 +2071,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2013,8 +2080,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -2024,7 +2091,7 @@
 				},
 				"is-number": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"optional": true,
 					"requires": {
@@ -2033,7 +2100,7 @@
 					"dependencies": {
 						"kind-of": {
 							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"optional": true,
 							"requires": {
@@ -2044,19 +2111,20 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+					"optional": true
 				},
 				"micromatch": {
 					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
 					"optional": true,
 					"requires": {
 						"arr-diff": "^4.0.0",
@@ -2078,13 +2146,13 @@
 		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
 		},
 		"regex-cache": {
 			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
 			"optional": true,
 			"requires": {
 				"is-equal-shallow": "^0.1.3"
@@ -2092,8 +2160,9 @@
 		},
 		"regex-not": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+			"optional": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
@@ -2101,22 +2170,25 @@
 		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"optional": true
 		},
 		"repeat-element": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+			"optional": true
 		},
 		"repeat-string": {
 			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"optional": true
 		},
 		"repeating": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
 				"is-finite": "^1.0.0"
@@ -2124,31 +2196,35 @@
 		},
 		"resolve-url": {
 			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"optional": true
 		},
 		"ret": {
 			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+			"optional": true
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"optional": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
 		},
 		"set-value": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
+			"optional": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -2158,8 +2234,9 @@
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -2168,13 +2245,14 @@
 		},
 		"slash": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/slash/-/slash-1.0.0.tgz",
 			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+			"optional": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -2186,26 +2264,20 @@
 				"use": "^3.1.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
 				"define-property": {
 					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -2214,8 +2286,8 @@
 		},
 		"snapdragon-node": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
 			"optional": true,
 			"requires": {
 				"define-property": "^1.0.0",
@@ -2225,7 +2297,7 @@
 			"dependencies": {
 				"define-property": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"optional": true,
 					"requires": {
@@ -2234,8 +2306,8 @@
 				},
 				"is-accessor-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
 					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2243,8 +2315,8 @@
 				},
 				"is-data-descriptor": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
 					"optional": true,
 					"requires": {
 						"kind-of": "^6.0.0"
@@ -2252,8 +2324,8 @@
 				},
 				"is-descriptor": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
 					"optional": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
@@ -2263,21 +2335,22 @@
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"optional": true
 				},
 				"kind-of": {
 					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+					"optional": true
 				}
 			}
 		},
 		"snapdragon-util": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
 			"optional": true,
 			"requires": {
 				"kind-of": "^3.2.0"
@@ -2285,13 +2358,14 @@
 		},
 		"source-map": {
 			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+			"optional": true,
 			"requires": {
 				"atob": "^2.1.1",
 				"decode-uri-component": "^0.2.0",
@@ -2302,29 +2376,32 @@
 		},
 		"source-map-support": {
 			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/source-map-support/-/source-map-support-0.4.18.tgz",
+			"integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
 			"requires": {
 				"source-map": "^0.5.6"
 			}
 		},
 		"source-map-url": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"optional": true
 		},
 		"split-string": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+			"optional": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"optional": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -2332,8 +2409,9 @@
 			"dependencies": {
 				"define-property": {
 					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"optional": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -2342,8 +2420,8 @@
 		},
 		"string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
 			"optional": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
@@ -2351,7 +2429,7 @@
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
 				"ansi-regex": "^2.0.0"
@@ -2359,26 +2437,28 @@
 		},
 		"supports-color": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
 			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
 		},
 		"to-fast-properties": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"optional": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
 		},
 		"to-regex": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+			"optional": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -2388,7 +2468,7 @@
 		},
 		"to-regex-range": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"optional": true,
 			"requires": {
@@ -2398,7 +2478,7 @@
 			"dependencies": {
 				"is-number": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"optional": true,
 					"requires": {
@@ -2409,13 +2489,14 @@
 		},
 		"trim-right": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/trim-right/-/trim-right-1.0.1.tgz",
 			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
 		},
 		"union-value": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"optional": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -2425,16 +2506,18 @@
 			"dependencies": {
 				"extend-shallow": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"optional": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
 					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"optional": true,
 					"requires": {
 						"extend-shallow": "^2.0.1",
 						"is-extendable": "^0.1.1",
@@ -2446,8 +2529,9 @@
 		},
 		"unset-value": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"optional": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -2455,8 +2539,9 @@
 			"dependencies": {
 				"has-value": {
 					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"optional": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -2465,8 +2550,9 @@
 					"dependencies": {
 						"isobject": {
 							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"optional": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -2475,40 +2561,44 @@
 				},
 				"has-values": {
 					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"optional": true
 				},
 				"isobject": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+					"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"optional": true
 				}
 			}
 		},
 		"urix": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"optional": true
 		},
 		"use": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/use/-/use-3.1.1.tgz",
+			"integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+			"optional": true
 		},
 		"user-home": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/user-home/-/user-home-1.1.1.tgz",
 			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"optional": true
 		},
 		"v8flags": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/v8flags/-/v8flags-2.1.1.tgz",
 			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
 			"requires": {
 				"user-home": "^1.1.1"
@@ -2516,7 +2606,7 @@
 		},
 		"wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		}
 	}

--- a/packages/api-axios/src/tests/api.test.js
+++ b/packages/api-axios/src/tests/api.test.js
@@ -14,7 +14,7 @@ import Api, {
   avFilesApi,
   avFilesDeliveryApi,
   avSettingsApi,
-} from '../';
+} from '..';
 
 describe('AvAPi', () => {
   test('should be defined', () => {

--- a/packages/api-core/package-lock.json
+++ b/packages/api-core/package-lock.json
@@ -1,11 +1,18 @@
 {
-	"requires": true,
+	"name": "@availity/api-core",
+	"version": "3.0.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"version": "6.6.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/qs/-/qs-6.6.0.tgz",
+			"integrity": "sha1-qZwPaajSa/fvAS+HHNq7Cu5EJMI="
 		}
 	}
 }

--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -63,7 +63,7 @@ export default class AvApi {
   // get the cache value with default function
   getCacheBustVal(cacheBust, defaultFn) {
     if (!cacheBust) {
-      return;
+      return undefined;
     }
 
     if (typeof cacheBust === 'boolean' && defaultFn) {

--- a/packages/api-core/src/resources/files.js
+++ b/packages/api-core/src/resources/files.js
@@ -21,7 +21,9 @@ export default class AvFiles extends AvMicroservice {
 
   uploadFile(data, config) {
     if (!config.customerId || !config.clientId) {
-      throw Error('[config.customerId] and [config.clientId] must be defined');
+      throw new Error(
+        '[config.customerId] and [config.clientId] must be defined'
+      );
     }
     config = this.config(config);
     config.headers['X-Availity-Customer-ID'] = config.customerId;

--- a/packages/api-core/src/resources/filesDelivery.js
+++ b/packages/api-core/src/resources/filesDelivery.js
@@ -23,7 +23,9 @@ export default class AvFilesDelivery extends AvMicroservice {
 
   uploadFilesDelivery(data, config) {
     if (!config.customerId || !config.clientId) {
-      throw Error('[config.customerId] and [config.clientId] must be defined');
+      throw new Error(
+        '[config.customerId] and [config.clientId] must be defined'
+      );
     }
     config = this.config(config);
     config.headers['X-Availity-Customer-ID'] = config.customerId;

--- a/packages/api-core/src/resources/proxy.js
+++ b/packages/api-core/src/resources/proxy.js
@@ -3,7 +3,7 @@ import AvApi from '../api';
 export default class AvProxy extends AvApi {
   constructor({ http, promise, merge, config }) {
     if (!config || !config.tenant) {
-      throw Error('Must specify tenant name for Proxy');
+      throw new Error('Must specify tenant name for Proxy');
     }
     const options = Object.assign(
       {

--- a/packages/api-core/src/resources/spaces.js
+++ b/packages/api-core/src/resources/spaces.js
@@ -36,7 +36,7 @@ export default class AvSpaces extends AvApi {
 
   getSpaceName(spaceId) {
     if (!spaceId) {
-      throw Error('[spaceId] must be defined');
+      throw new Error('[spaceId] must be defined');
     }
     return this.get(spaceId).then(response => response.data.name);
   }

--- a/packages/api-core/src/resources/tests/pdfs.test.js
+++ b/packages/api-core/src/resources/tests/pdfs.test.js
@@ -25,7 +25,7 @@ describe('AvPdfs', () => {
     });
     expect(() => {
       api = api.getPdf({});
-    }).toThrowError('[applicationId], [fileName] and [html] must be defined');
+    }).toThrow('[applicationId], [fileName] and [html] must be defined');
   });
 
   test('should call onPdf() when pdf completes', async () => {

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -31,7 +31,7 @@ describe('AvApi', () => {
         merge: false,
         config: false,
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       api = new AvApi({
@@ -40,7 +40,7 @@ describe('AvApi', () => {
         merge: mockMerge,
         config: {},
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       api = new AvApi({
@@ -49,7 +49,7 @@ describe('AvApi', () => {
         merge: mockMerge,
         config: {},
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       api = new AvApi({
@@ -58,7 +58,7 @@ describe('AvApi', () => {
         merge: false,
         config: {},
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       api = new AvApi({
@@ -67,7 +67,7 @@ describe('AvApi', () => {
         merge: mockMerge,
         config: false,
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
   });
 
   test('getQueryResultKey(data) should determine the key for the list within data', () => {
@@ -171,7 +171,7 @@ describe('AvApi', () => {
       const testResponse = 'test';
       const defaultFn = jest.fn(() => testResponse);
       expect(api.getCacheBustVal(testCache, defaultFn)).toBe(testResponse);
-      expect(defaultFn).toBeCalled();
+      expect(defaultFn).toHaveBeenCalled();
     });
 
     test('should call and return passed in function', () => {
@@ -179,8 +179,8 @@ describe('AvApi', () => {
       const testCache = jest.fn(() => testResponse);
       const defaultFn = jest.fn(() => `${testResponse}2`);
       expect(api.getCacheBustVal(testCache, defaultFn)).toBe(testResponse);
-      expect(testCache).toBeCalled();
-      expect(defaultFn).not.toBeCalled();
+      expect(testCache).toHaveBeenCalled();
+      expect(defaultFn).not.toHaveBeenCalled();
     });
   });
 
@@ -207,7 +207,7 @@ describe('AvApi', () => {
     Date.now = jest.fn(() => test);
     api.setPageBust();
     expect(api.pageBustValue).toBe(test);
-    expect(Date.now).toBeCalled();
+    expect(Date.now).toHaveBeenCalled();
   });
 
   test('getPageBust() should return pageBustValue() if set', () => {
@@ -234,7 +234,7 @@ describe('AvApi', () => {
       api.pageBustValue = test;
     });
     expect(api.getPageBust()).toBe(test);
-    expect(api.setPageBust).toBeCalled();
+    expect(api.setPageBust).toHaveBeenCalled();
   });
 
   describe('addParams', () => {
@@ -376,7 +376,7 @@ describe('AvApi', () => {
       };
       api.cacheParams(testConfig);
       expect(testConfig.params.sessionBust).toBe(localStorageVal);
-      expect(api.localStorage.getSessionBust).toBeCalled();
+      expect(api.localStorage.getSessionBust).toHaveBeenCalled();
     });
 
     test("sessionBust defaultFn should use pageBust value when  localStorage's sessionBust is not available", () => {
@@ -388,7 +388,7 @@ describe('AvApi', () => {
       };
       api.cacheParams(testConfig);
       expect(testConfig.params.sessionBust).toBe(testPageBust);
-      expect(api.localStorage.getSessionBust).toBeCalled();
+      expect(api.localStorage.getSessionBust).toHaveBeenCalled();
     });
   });
 
@@ -592,7 +592,7 @@ describe('AvApi', () => {
       };
       api.getLocation.mockImplementationOnce(() => false);
       expect(api.onResponse(testResponse)).toEqual(testResponse);
-      expect(api.request).not.toBeCalled();
+      expect(api.request).not.toHaveBeenCalled();
     });
 
     test('should return result of afterResponse if no polling', () => {
@@ -607,8 +607,8 @@ describe('AvApi', () => {
       expect(api.onResponse(testResponse, afterResponse)).toEqual(
         testResponse2
       );
-      expect(api.request).not.toBeCalled();
-      expect(afterResponse).toBeCalledWith(testResponse);
+      expect(api.request).not.toHaveBeenCalled();
+      expect(afterResponse).toHaveBeenCalledWith(testResponse);
     });
 
     test('should request when polling', () => {

--- a/packages/api-core/src/tests/ms.test.js
+++ b/packages/api-core/src/tests/ms.test.js
@@ -8,7 +8,7 @@ const defaultPath = API_OPTIONS.MS.path;
 describe('AvMicroservice', () => {
   let ms;
 
-  test('AvMicroservice should be defined', () => {
+  test('should be defined', () => {
     ms = new AvMicroservice({
       http: mockHttp,
       promise: Promise,
@@ -18,7 +18,7 @@ describe('AvMicroservice', () => {
     expect(ms).toBeDefined();
   });
 
-  test('AvMicroservice should throw errors when missing paramaters', () => {
+  test('should throw errors when missing paramaters', () => {
     // expect(() => {
     //   ms = new AvMicroservice();
     // }).toThrowError('[http], [promise], [config], and [merge] must be defined');
@@ -30,7 +30,7 @@ describe('AvMicroservice', () => {
         merge: false,
         config: false,
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       ms = new AvMicroservice({
@@ -39,7 +39,7 @@ describe('AvMicroservice', () => {
         merge: mockMerge,
         config: {},
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       ms = new AvMicroservice({
@@ -48,7 +48,7 @@ describe('AvMicroservice', () => {
         merge: mockMerge,
         config: {},
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       ms = new AvMicroservice({
@@ -57,7 +57,7 @@ describe('AvMicroservice', () => {
         merge: false,
         config: {},
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
 
     expect(() => {
       ms = new AvMicroservice({
@@ -66,7 +66,7 @@ describe('AvMicroservice', () => {
         merge: mockMerge,
         config: false,
       });
-    }).toThrowError('[http], [promise], [config], and [merge] must be defined');
+    }).toThrow('[http], [promise], [config], and [merge] must be defined');
   });
 
   test('config() should be API_OPTIONS_MS default', () => {
@@ -114,7 +114,6 @@ describe('AvMicroservice', () => {
 
     test('get() should build url with id', async () => {
       await ms.get(1);
-
       expect(mockHttp.mock.calls[0][0].url).toBe('/ms/api/availity/internal/1');
     });
 

--- a/packages/authorizations-angular/package-lock.json
+++ b/packages/authorizations-angular/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "@availity/authorizations-angular",
+	"version": "2.6.2",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"angular": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular/-/angular-1.7.3.tgz",
-			"integrity": "sha512-hQRhU56shs72y88cS0Uy9g+UAMHoztJ3V+r+iF8o1AK/Bpu8ewmjFDk9j2LjSuN05a9mhxW1rOHnYKOwyTS/Zg=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular/-/angular-1.7.7.tgz",
+			"integrity": "sha1-Jr2HaT3q3L1ZRGEKegRj/HmhiAM=",
+			"dev": true
 		},
 		"angular-mocks": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.7.3.tgz",
-			"integrity": "sha512-j9JZxJiTdwr1oZPtQQFSMpfNZiY+LzKJaodVeWCdXMA1+mOXxS2f8k0yEnG618O2LHd/MU8z3IibyVgbl9xuiA=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular-mocks/-/angular-mocks-1.7.7.tgz",
+			"integrity": "sha1-In/sqKfpzGHEaANm2wJNZWPUxus=",
+			"dev": true
 		}
 	}
 }

--- a/packages/authorizations-angular/src/tests/test.js
+++ b/packages/authorizations-angular/src/tests/test.js
@@ -1,6 +1,6 @@
 import angular from 'angular';
 import 'angular-mocks';
-import avModule from '../';
+import avModule from '..';
 
 describe('avAuthorizations', () => {
   let avAuthorizations;

--- a/packages/authorizations-axios/package-lock.json
+++ b/packages/authorizations-axios/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "@availity/authorizations-axios",
+	"version": "3.0.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"axios": {
 			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/axios/-/axios-0.17.1.tgz",
 			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"dev": true,
 			"requires": {
 				"follow-redirects": "^1.2.5",
 				"is-buffer": "^1.1.5"
@@ -13,29 +16,33 @@
 		},
 		"debug": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
 		},
 		"follow-redirects": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
-			"integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
+			"version": "1.6.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.6.1.tgz",
+			"integrity": "sha1-UUlzxEtXVzaLrYvd/lL4HwFclMs=",
+			"dev": true,
 			"requires": {
-				"debug": "^3.1.0"
+				"debug": "=3.1.0"
 			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+			"dev": true
 		},
 		"ms": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		}
 	}
 }

--- a/packages/authorizations-axios/src/tests/test.js
+++ b/packages/authorizations-axios/src/tests/test.js
@@ -1,4 +1,4 @@
-import avAuthorizations from '../';
+import avAuthorizations from '..';
 
 describe('AvAuthorizations', () => {
   test('AvAuthorizations should be defined', () => {

--- a/packages/authorizations-core/src/index.js
+++ b/packages/authorizations-core/src/index.js
@@ -2,7 +2,7 @@ class AvAuthorizations {
   constructor(avPermissions, avRegions, promise) {
     // make sure all params are passed in
     if (!avPermissions || !avRegions || !promise) {
-      throw Error('A permission, region, and promise are required');
+      throw new Error('A permission, region, and promise are required');
     }
 
     // save paramaters

--- a/packages/authorizations-core/src/tests/test.js
+++ b/packages/authorizations-core/src/tests/test.js
@@ -1,4 +1,4 @@
-import AvAuthorizations from '../';
+import AvAuthorizations from '..';
 
 expect.extend({
   toBeAuthorized(permissions, ids) {
@@ -107,7 +107,7 @@ describe('AvAuthorizations', () => {
   test('AvAuthorizations throws error when constructed without all params', () => {
     expect(() => {
       testAuthorizations = new AvAuthorizations();
-    }).toThrowError('A permission, region, and promise are required');
+    }).toThrow('A permission, region, and promise are required');
   });
 
   describe('Add permissions to map', () => {
@@ -192,7 +192,7 @@ describe('AvAuthorizations', () => {
 
   test('getRegion should use region api when no region is given', async () => {
     const region = await testAuthorizations.getRegion();
-    expect(mockRegions.getCurrentRegion).toBeCalled();
+    expect(mockRegions.getCurrentRegion).toHaveBeenCalled();
     expect(region).toBe(mockRegion);
   });
 
@@ -257,7 +257,7 @@ describe('AvAuthorizations', () => {
     test('Get permissions should call permission api', async () => {
       const testIds = ['123', '456'];
       await testAuthorizations.getPermissions(testIds);
-      expect(mockPermissions.getPermissions).toBeCalled();
+      expect(mockPermissions.getPermissions).toHaveBeenCalled();
     });
 
     test('should return requested permissions with isAuthorized flag set', async () => {
@@ -271,8 +271,8 @@ describe('AvAuthorizations', () => {
       const testIds = '123';
       try {
         await testAuthorizations.getPermissions(testIds);
-      } catch (err) {
-        expect(err).toBe('permissionIds must be an array of strings');
+      } catch (error) {
+        expect(error).toBe('permissionIds must be an array of strings');
       }
     });
 
@@ -280,8 +280,8 @@ describe('AvAuthorizations', () => {
       const testIds = ['123', 456];
       try {
         await testAuthorizations.getPermissions(testIds);
-      } catch (err) {
-        expect(err).toBe('permissionIds must be an array of strings');
+      } catch (error) {
+        expect(error).toBe('permissionIds must be an array of strings');
       }
     });
   });
@@ -293,14 +293,17 @@ describe('AvAuthorizations', () => {
       testId,
       testRegion
     );
-    expect(mockPermissions.getPermissions).lastCalledWith([testId], testRegion);
+    expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
+      [testId],
+      testRegion
+    );
     expect(permission).toEqual(getMockPermissionValues([testId], true)[0]);
   });
 
   test('getPermission should reject when a non-string is passed in', () => {
     const testId = 123;
-    return testAuthorizations.getPermission(testId).catch(err => {
-      expect(err).toBe('permissionId must be a string');
+    return testAuthorizations.getPermission(testId).catch(error => {
+      expect(error).toBe('permissionId must be a string');
     });
   });
 
@@ -312,7 +315,7 @@ describe('AvAuthorizations', () => {
         testId,
         testRegion
       );
-      expect(mockPermissions.getPermissions).lastCalledWith(
+      expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
         [testId],
         testRegion
       );
@@ -330,7 +333,7 @@ describe('AvAuthorizations', () => {
         testRegion
       );
 
-      expect(mockPermissions.getPermissions).lastCalledWith(
+      expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
         [testId],
         testRegion
       );
@@ -345,7 +348,7 @@ describe('AvAuthorizations', () => {
         testRegion
       );
 
-      expect(mockPermissions.getPermissions).lastCalledWith(
+      expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
         testIds,
         testRegion
       );
@@ -361,13 +364,13 @@ describe('AvAuthorizations', () => {
         unauthorizedMockPermissions
       );
       await testAuthorizations.getPermissions(testIdsFalse, testRegion);
-      expect(mockPermissions.getPermissions).lastCalledWith(
+      expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
         testIdsFalse,
         testRegion
       );
 
       await testAuthorizations.getPermissions(testIdsTrue, testRegion);
-      expect(mockPermissions.getPermissions).lastCalledWith(
+      expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
         testIdsTrue,
         testRegion
       );
@@ -389,7 +392,7 @@ describe('AvAuthorizations', () => {
         testIds,
         testRegion
       );
-      expect(mockPermissions.getPermissions).lastCalledWith(
+      expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
         testIds,
         testRegion
       );
@@ -402,7 +405,10 @@ describe('AvAuthorizations', () => {
     const testId2 = '456';
     const testRegion = 'GA';
     let orgs = await testAuthorizations.getOrganizations(testId, testRegion);
-    expect(mockPermissions.getPermissions).lastCalledWith([testId], testRegion);
+    expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
+      [testId],
+      testRegion
+    );
     expect(orgs).toEqual(
       getMockPermissionValues([testId], true)[0].organizations
     );
@@ -410,7 +416,7 @@ describe('AvAuthorizations', () => {
       unauthorizedMockPermissions
     );
     orgs = await testAuthorizations.getOrganizations(testId2, testRegion);
-    expect(mockPermissions.getPermissions).lastCalledWith(
+    expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
       [testId2],
       testRegion
     );
@@ -426,14 +432,17 @@ describe('AvAuthorizations', () => {
     const testResource = 'testResources';
     const testRegion = 'GA';
     let payers = await testAuthorizations.getPayers(testId, orgId, testRegion);
-    expect(mockPermissions.getPermissions).lastCalledWith([testId], testRegion);
+    expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
+      [testId],
+      testRegion
+    );
     expect(payers).toEqual(testResource);
     mockPermissions.getPermissions.mockImplementationOnce(
       unauthorizedMockPermissions
     );
 
     payers = await testAuthorizations.getPayers(testId2, orgId, testRegion);
-    expect(mockPermissions.getPermissions).lastCalledWith(
+    expect(mockPermissions.getPermissions).toHaveBeenLastCalledWith(
       [testId2],
       testRegion
     );

--- a/packages/dl-angular/package-lock.json
+++ b/packages/dl-angular/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "@availity/dl-angular",
+	"version": "2.6.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"angular": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/angular/-/angular-1.7.2.tgz",
-			"integrity": "sha512-JcKKJbBdybUsmQ6x1M3xWyTYQ/ioVKJhSByEAjqrhmlOfvMFdhfMqAx5KIo8rLGk4DFolYPcCSgssjgTVjCtRQ=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular/-/angular-1.7.7.tgz",
+			"integrity": "sha1-Jr2HaT3q3L1ZRGEKegRj/HmhiAM=",
+			"dev": true
 		},
 		"angular-mocks": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.7.2.tgz",
-			"integrity": "sha512-yj9eWPG0usXX2eDTWM6YOmAGKraT7qHwuD+NrNyaR+mtrNr2ls77WuWXTjE1hZpmxTaGj4+R1nMY696XZn740Q=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular-mocks/-/angular-mocks-1.7.7.tgz",
+			"integrity": "sha1-In/sqKfpzGHEaANm2wJNZWPUxus=",
+			"dev": true
 		}
 	}
 }

--- a/packages/dl-axios/package-lock.json
+++ b/packages/dl-axios/package-lock.json
@@ -1,11 +1,14 @@
 {
-	"requires": true,
+	"name": "@availity/dl-axios",
+	"version": "2.6.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"axios": {
 			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/axios/-/axios-0.17.1.tgz",
 			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"dev": true,
 			"requires": {
 				"follow-redirects": "^1.2.5",
 				"is-buffer": "^1.1.5"
@@ -13,29 +16,33 @@
 		},
 		"debug": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			}
 		},
 		"follow-redirects": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-			"integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+			"version": "1.6.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.6.1.tgz",
+			"integrity": "sha1-UUlzxEtXVzaLrYvd/lL4HwFclMs=",
+			"dev": true,
 			"requires": {
-				"debug": "^3.1.0"
+				"debug": "=3.1.0"
 			}
 		},
 		"is-buffer": {
 			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+			"dev": true
 		},
 		"ms": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		}
 	}
 }

--- a/packages/dl-core/package-lock.json
+++ b/packages/dl-core/package-lock.json
@@ -1,11 +1,13 @@
 {
-	"requires": true,
+	"name": "@availity/dl-core",
+	"version": "2.6.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"js-file-download": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.1.tgz",
-			"integrity": "sha1-3g3S1mHVY19QanO5YqtY3bZQvts="
+			"version": "0.4.4",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/js-file-download/-/js-file-download-0.4.4.tgz",
+			"integrity": "sha1-Uf+l1CH8X8JcnRpyQlWnGE5NySs="
 		}
 	}
 }

--- a/packages/dl-core/src/download.js
+++ b/packages/dl-core/src/download.js
@@ -4,7 +4,7 @@ import fileDownload from 'js-file-download';
 export default class DownloadMicroservice extends AvMicroservice {
   constructor({ http, promise, merge, config }) {
     if (!config.clientId) {
-      throw Error('[config.clientId] must be defined');
+      throw new Error('[config.clientId] must be defined');
     }
 
     const options = Object.assign(

--- a/packages/env-var/index.js
+++ b/packages/env-var/index.js
@@ -39,6 +39,7 @@ export function getCurrentEnv(windowOverride = window) {
           case '[object RegExp]':
             return test.test(subdomain);
           case '[object Function]':
+            // eslint-disable-next-line jest/no-disabled-tests
             return test();
           default:
             return false;

--- a/packages/env-var/tests/.eslintrc.yml
+++ b/packages/env-var/tests/.eslintrc.yml
@@ -1,5 +1,0 @@
-extends: availity/browser
-env:
-  jest: true
-globals:
-  jsdom: true

--- a/packages/env-var/tests/test.js
+++ b/packages/env-var/tests/test.js
@@ -1,6 +1,7 @@
 import envVar, { setEnvironments } from '../index';
 
 const setHostname = hostname => {
+  // eslint-disable-next-line no-undef
   jsdom.reconfigure({
     url: `https://${hostname}/`,
   });

--- a/packages/exceptions-angular/package-lock.json
+++ b/packages/exceptions-angular/package-lock.json
@@ -1,16 +1,20 @@
 {
-	"requires": true,
+	"name": "@availity/exceptions-angular",
+	"version": "2.7.1",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"angular": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular/-/angular-1.7.3.tgz",
-			"integrity": "sha512-hQRhU56shs72y88cS0Uy9g+UAMHoztJ3V+r+iF8o1AK/Bpu8ewmjFDk9j2LjSuN05a9mhxW1rOHnYKOwyTS/Zg=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular/-/angular-1.7.7.tgz",
+			"integrity": "sha1-Jr2HaT3q3L1ZRGEKegRj/HmhiAM=",
+			"dev": true
 		},
 		"angular-mocks": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/angular-mocks/-/angular-mocks-1.7.3.tgz",
-			"integrity": "sha512-j9JZxJiTdwr1oZPtQQFSMpfNZiY+LzKJaodVeWCdXMA1+mOXxS2f8k0yEnG618O2LHd/MU8z3IibyVgbl9xuiA=="
+			"version": "1.7.7",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/angular-mocks/-/angular-mocks-1.7.7.tgz",
+			"integrity": "sha1-In/sqKfpzGHEaANm2wJNZWPUxus=",
+			"dev": true
 		}
 	}
 }

--- a/packages/exceptions-angular/src/index.js
+++ b/packages/exceptions-angular/src/index.js
@@ -10,8 +10,9 @@ class AvExceptionsProvider {
     this.thisAppid = undefined;
     this.REPEAT_LIMIT = undefined;
   }
+
   enabled(value) {
-    if (arguments.length) {
+    if (arguments.length > 0) {
       this.isEnabled = !!value;
     }
     return this.isEnabled;

--- a/packages/exceptions-angular/src/tests/test.js
+++ b/packages/exceptions-angular/src/tests/test.js
@@ -3,7 +3,7 @@ import 'angular-mocks';
 
 import AvExceptionsCore from '@availity/exceptions-core';
 
-import AvModule from '../';
+import AvModule from '..';
 
 const DEFAULT_REPEAT = new AvExceptionsCore(jest.fn()).REPEAT_LIMIT;
 

--- a/packages/exceptions-core/package-lock.json
+++ b/packages/exceptions-core/package-lock.json
@@ -1,42 +1,50 @@
 {
-	"requires": true,
+	"name": "@availity/exceptions-core",
+	"version": "2.5.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"error-stack-parser": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
-			"integrity": "sha512-E1fPutRDdIj/hohG0UpT5mayXNCxXP9d+snxFsPU9X0XgccOumKraa3juDMwTUyi7+Bu5+mCGagjg4IYeNbOdw==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/error-stack-parser/-/error-stack-parser-2.0.2.tgz",
+			"integrity": "sha1-Sujbqiv5CotFBwe5FJ3KvKE1Ug0=",
+			"dev": true,
 			"requires": {
 				"stackframe": "^1.0.4"
 			}
 		},
 		"mockdate": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mockdate/-/mockdate-2.0.2.tgz",
-			"integrity": "sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/mockdate/-/mockdate-2.0.2.tgz",
+			"integrity": "sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=",
+			"dev": true
 		},
 		"source-map": {
 			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/source-map/-/source-map-0.5.6.tgz",
+			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+			"dev": true
 		},
 		"stack-generator": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.3.tgz",
-			"integrity": "sha512-kdzGoqrnqsMxOEuXsXyQTmvWXZmG0f3Ql2GDx5NtmZs59sT2Bt9Vdyq0XdtxUi58q/+nxtbF9KOQ9HkV1QznGg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/stack-generator/-/stack-generator-2.0.3.tgz",
+			"integrity": "sha1-u3Q4XGf/xMzzxN7lgxgy1OUJyKA=",
+			"dev": true,
 			"requires": {
 				"stackframe": "^1.0.4"
 			}
 		},
 		"stackframe": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.0.4.tgz",
-			"integrity": "sha512-to7oADIniaYwS3MhtCa/sQhrxidCCQiF/qp4/m5iN3ipf0Y7Xlri0f6eG29r08aL7JYl8n32AF3Q5GYBZ7K8vw=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/stackframe/-/stackframe-1.0.4.tgz",
+			"integrity": "sha1-NXskqZL5Qny6a1RdlqFO0svKGHs=",
+			"dev": true
 		},
 		"stacktrace-gps": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
-			"integrity": "sha512-9o+nWhiz5wFnrB3hBHs2PTyYrS60M1vvpSzHxwxnIbtY2q9Nt51hZvhrG1+2AxD374ecwyS+IUwfkHRE/2zuGg==",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/stacktrace-gps/-/stacktrace-gps-3.0.2.tgz",
+			"integrity": "sha1-M/i6pEZzI6sr0YFu+ieZQrpDHMw=",
+			"dev": true,
 			"requires": {
 				"source-map": "0.5.6",
 				"stackframe": "^1.0.4"
@@ -44,8 +52,9 @@
 		},
 		"stacktrace-js": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/stacktrace-js/-/stacktrace-js-2.0.0.tgz",
 			"integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
+			"dev": true,
 			"requires": {
 				"error-stack-parser": "^2.0.1",
 				"stack-generator": "^2.0.1",

--- a/packages/exceptions-core/src/index.js
+++ b/packages/exceptions-core/src/index.js
@@ -14,9 +14,9 @@ export default class AvExceptions {
 
     this.StackTrace = StackTrace;
 
-    window.onerror = (msg, file, line, col, error) => {
+    window.addEventListener('error', (msg, file, line, col, error) => {
       this.submitError(error);
-    }
+    });
   }
 
   submitError(error) {
@@ -28,7 +28,7 @@ export default class AvExceptions {
   }
 
   enabled(value) {
-    if (arguments.length) {
+    if (arguments.length > 0) {
       this.isEnabled = !!value;
     }
     return this.isEnabled;
@@ -89,7 +89,7 @@ export default class AvExceptions {
       !exception ||
       (!skipRepeat && this.isRepeatError(exception))
     ) {
-      return;
+      return undefined;
     }
 
     const errorMessage = exception.message;

--- a/packages/exceptions-core/src/tests/test.js
+++ b/packages/exceptions-core/src/tests/test.js
@@ -1,6 +1,5 @@
-/* eslint-disable promise/no-callback-in-promise, promise/valid-params */
 import MockDate from 'mockdate';
-import AvExceptions from '../';
+import AvExceptions from '..';
 
 jest.useFakeTimers();
 
@@ -11,7 +10,7 @@ describe('AvExceptions', () => {
   let mockExceptions;
 
   beforeEach(() => {
-    mockLog = jest.fn(console.log.bind(console)); // eslint-disable-line
+    mockLog = jest.fn(console.log.bind(console)); // eslint-disable-line no-console
   });
 
   test('AvExceptions should be defined', () => {
@@ -140,8 +139,8 @@ describe('AvExceptions', () => {
 
       try {
         throw new Error('mock error');
-      } catch (e) {
-        exception = e;
+      } catch (error) {
+        exception = error;
       }
     });
 
@@ -169,9 +168,10 @@ describe('AvExceptions', () => {
         .then(() => {
           expect(mockExceptions.isRepeatError).not.toHaveBeenCalled();
           expect(mockLog).toHaveBeenCalled();
+          // eslint-disable-next-line promise/no-callback-in-promise
           return done();
         })
-        .catch();
+        .catch(error => error);
     });
 
     test('should build message and reset currentHits to 0', done => {
@@ -209,9 +209,10 @@ describe('AvExceptions', () => {
           expect(
             mockExceptions.errorMessageHistory[errorMessage].currentHits
           ).toBe(0);
+          // eslint-disable-next-line promise/no-callback-in-promise
           return done();
         })
-        .catch();
+        .catch(error => error);
     });
 
     test('should merge errorMessage into message if defined', done => {
@@ -263,9 +264,10 @@ describe('AvExceptions', () => {
         .then(() => {
           expect(mockLog).toHaveBeenCalledWith(expectedCall);
           expect(mockExceptions.errorMessage).toHaveBeenCalled();
+          // eslint-disable-next-line promise/no-callback-in-promise
           return done();
         })
-        .catch();
+        .catch(error => error);
     });
   });
 

--- a/packages/keyv-local-sync/package-lock.json
+++ b/packages/keyv-local-sync/package-lock.json
@@ -1,10 +1,12 @@
 {
-	"requires": true,
+	"name": "@availity/keyv-local-sync",
+	"version": "2.5.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"quick-lru": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		}
 	}

--- a/packages/keyv-local-sync/src/test.js
+++ b/packages/keyv-local-sync/src/test.js
@@ -1,4 +1,4 @@
-import Keyv from './';
+import Keyv from '.';
 
 describe('Keyv', () => {
   test('should exist', () => {
@@ -9,7 +9,8 @@ describe('Keyv', () => {
     }).toThrow();
 
     expect(() => {
-      new Keyv(); // eslint-disable-line
+      // eslint-disable-next-line no-new
+      new Keyv();
     }).not.toThrow();
   });
 

--- a/packages/localstorage-core/src/index.js
+++ b/packages/localstorage-core/src/index.js
@@ -5,7 +5,7 @@ class AvLocalStorage {
     let output;
     try {
       output = JSON.parse(value);
-    } catch (e) {
+    } catch (error) {
       output = value;
     }
     return output;
@@ -37,6 +37,8 @@ class AvLocalStorage {
       }
       return output;
     }
+
+    return undefined;
   }
 
   removeKeys(searchKey) {

--- a/packages/localstorage-core/src/tests/test.js
+++ b/packages/localstorage-core/src/tests/test.js
@@ -1,4 +1,4 @@
-import AvLocalStorage from '../';
+import AvLocalStorage from '..';
 
 let avLocalStorage;
 

--- a/packages/message-core/src/AvMessage.js
+++ b/packages/message-core/src/AvMessage.js
@@ -9,7 +9,7 @@ class AvMessage {
   }
 
   enabled(value) {
-    if (arguments.length) {
+    if (arguments.length > 0) {
       this.isEnabled = !!value;
     }
     return this.isEnabled;
@@ -21,7 +21,7 @@ class AvMessage {
       !event ||
       !event.data ||
       !event.origin ||
-      !event.source || // check event exists and has necesary properties
+      !event.source || // check event exists and has necessary properties
       event.source === window || // don't process messages emitted from the same window
       !this.isDomain(event.origin)
     ) {
@@ -34,8 +34,9 @@ class AvMessage {
     if (typeof data === 'string') {
       try {
         data = JSON.parse(data);
-      } catch (e) {
-        // warn about error
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log(error);
       }
     }
 
@@ -106,8 +107,9 @@ class AvMessage {
       const message =
         typeof payload === 'string' ? payload : JSON.stringify(payload);
       target.postMessage(message, this.domain());
-    } catch (err) {
-      console.warn('AvMessage.send() ', err); // eslint-disable-line
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('AvMessage.send()', error);
     }
   }
 }

--- a/packages/native-form/index.js
+++ b/packages/native-form/index.js
@@ -32,6 +32,6 @@ export default (
     .join('');
 
   form.insertAdjacentHTML('beforeend', fields);
-  document.body.appendChild(form);
+  document.body.append(form);
   form.submit();
 };

--- a/packages/native-form/tests/test.js
+++ b/packages/native-form/tests/test.js
@@ -1,4 +1,4 @@
-import nativeForm from '../';
+import nativeForm from '..';
 import flattenObject from '../flattenObject';
 
 describe('nativeForm', () => {
@@ -50,7 +50,7 @@ describe('nativeForm', () => {
       if (form) form.remove();
     });
     test('spaceId is required', () => {
-      expect(() => nativeForm()).toThrowError(
+      expect(() => nativeForm()).toThrow(
         'spaceId is required and was not provided'
       );
     });

--- a/packages/upload-core/package-lock.json
+++ b/packages/upload-core/package-lock.json
@@ -1,36 +1,66 @@
 {
-	"requires": true,
+	"name": "@availity/upload-core",
+	"version": "2.6.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"buffer-from": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-			"integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/buffer-from/-/buffer-from-0.1.2.tgz",
+			"integrity": "sha1-FfS5vO8BIETfMRQsFDM8r24CYNA=",
+			"dev": true
 		},
 		"extend": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+			"dev": true
+		},
+		"js-base64": {
+			"version": "2.5.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/js-base64/-/js-base64-2.5.1.tgz",
+			"integrity": "sha1-Hvo57yxfeYC7F4St5KivLeMpESE=",
+			"dev": true
 		},
 		"lodash.throttle": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+			"dev": true
 		},
-		"resolve-url": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		"querystringify": {
+			"version": "2.1.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/querystringify/-/querystringify-2.1.0.tgz",
+			"integrity": "sha1-fe2N+/eHncxg0KZErGdUsoOtF+8=",
+			"dev": true
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
 		},
 		"tus-js-client": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/tus-js-client/-/tus-js-client-1.5.1.tgz",
-			"integrity": "sha512-qBSNXpc6ZPe6stn4NSkQ1dnVhVblPAtQo6037g5Qr5zr9gGX1gr+8e0+HtQMBp22Ouo6LYesWMdKbcOR5sRj5A==",
+			"version": "1.6.1",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/tus-js-client/-/tus-js-client-1.6.1.tgz",
+			"integrity": "sha1-S1xRy2p0MftEv3+W1hsRHpFDBDs=",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^0.1.1",
 				"extend": "^3.0.0",
+				"js-base64": "^2.4.9",
 				"lodash.throttle": "^4.1.1",
-				"resolve-url": "^0.2.1"
+				"url-parse": "^1.4.3"
+			}
+		},
+		"url-parse": {
+			"version": "1.4.4",
+			"resolved": "https://artifactory.availity.com/artifactory/api/npm/npm/url-parse/-/url-parse-1.4.4.tgz",
+			"integrity": "sha1-ysFVbpX6oDA2kf7Fz51aG8NGSPg=",
+			"dev": true,
+			"requires": {
+				"querystringify": "^2.0.0",
+				"requires-port": "^1.0.0"
 			}
 		}
 	}

--- a/packages/upload-core/src/tests/upload.test.js
+++ b/packages/upload-core/src/tests/upload.test.js
@@ -40,13 +40,15 @@ describe('upload.core', () => {
 
   it('should throw error for missing files', () => {
     expect(() => {
-      new Upload(); // eslint-disable-line
+      // eslint-disable-next-line no-new
+      new Upload();
     }).toThrow('[options.file] must be defined and of type File');
   });
 
   it('should throw error with missing bucket id', () => {
     expect(() => {
-      new Upload([]); // eslint-disable-line
+      // eslint-disable-next-line no-new
+      new Upload([]);
     }).toThrow('[options.bucketId] must be defined');
   });
 
@@ -60,13 +62,14 @@ describe('upload.core', () => {
   it('should allow single file as constructor argument', () => {
     const file = Buffer.from('hello world'.split(''));
     file.name = 'fileName.png';
-    new Upload(file, options); // eslint-disable-line
+    // eslint-disable-next-line no-new
+    new Upload(file, options);
   });
 
   it('should throw error for invalid file type', () => {
     const file = Buffer.from('hello world'.split(''));
     file.name = 'notCoolFile.docx';
-    const upload = new Upload(file, optionsWithFileTypes); // eslint-disable-line
+    const upload = new Upload(file, optionsWithFileTypes);
     upload.start();
     expect(upload.isValidFile()).toBeFalsy();
   });
@@ -74,7 +77,8 @@ describe('upload.core', () => {
   it('should allow the correct file type', () => {
     const file = Buffer.from('hello world'.split(''));
     file.name = 'coolFile.PNG';
-    new Upload(file, optionsWithFileTypes); // eslint-disable-line
+    // eslint-disable-next-line no-new
+    new Upload(file, optionsWithFileTypes);
   });
 
   it('should use default options', () => {

--- a/packages/upload-core/src/upload.js
+++ b/packages/upload-core/src/upload.js
@@ -5,8 +5,9 @@ const hashCode = str => {
   if (str.length === 0) return hash;
   for (let i = 0; i < str.length; i++) {
     const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char; // eslint-disable-line
-    hash = hash & hash; // eslint-disable-line
+    hash = (hash << 5) - hash + char; // eslint-disable-line no-bitwise
+    // eslint-disable-next-line operator-assignment
+    hash = hash & hash; // eslint-disable-line no-bitwise
   }
   return hash;
 };
@@ -44,19 +45,19 @@ const defaultOptions = {
 class Upload {
   constructor(file, options) {
     if (!file) {
-      throw Error('[options.file] must be defined and of type File(s)');
+      throw new Error('[options.file] must be defined and of type File(s)');
     }
 
     if (!options || !options.bucketId) {
-      throw Error('[options.bucketId] must be defined');
+      throw new Error('[options.bucketId] must be defined');
     }
 
     if (!options.customerId) {
-      throw Error('[options.customerId] must be defined');
+      throw new Error('[options.customerId] must be defined');
     }
 
     if (!options.clientId) {
-      throw Error('[options.clientId] must be defined');
+      throw new Error('[options.clientId] must be defined');
     }
 
     this.file = file;
@@ -72,7 +73,7 @@ class Upload {
     this.status = 'pending';
     this.timeoutID = undefined;
     this.error = null;
-    this.waitForPw = true;
+    this.waitForPassword = true;
   }
 
   inStatusCategory(status, category) {
@@ -97,6 +98,7 @@ class Upload {
       xhr.setRequestHeader(data.header, data.value);
     }
 
+    // eslint-disable-next-line unicorn/prefer-add-event-listener
     xhr.onload = () => {
       if (!this.inStatusCategory(xhr.status, 200)) {
         this.setError(
@@ -119,7 +121,7 @@ class Upload {
       }
 
       if (result.status === 'encrypted') {
-        if (this.waitForPw) {
+        if (this.waitForPassword) {
           this.setError(result.status, result.message);
           clearTimeout(this.timeoutId);
           return;
@@ -148,6 +150,7 @@ class Upload {
       }, 50);
     };
 
+    // eslint-disable-next-line unicorn/prefer-add-event-listener
     xhr.onerror = err => {
       this.setError('rejected', 'Network Error', err);
       this.error = err;
@@ -214,7 +217,7 @@ class Upload {
         if (!this.isValidFile()) {
           return;
         }
-        const xhr = this.upload._xhr; // eslint-disable-line
+        const xhr = this.upload._xhr;
         this.bytesScanned =
           parseInt(xhr.getResponseHeader('AV-Scan-Bytes'), 10) || 0;
         this.percentage = this.getPercentage();
@@ -250,7 +253,7 @@ class Upload {
   }
 
   sendPassword(pw) {
-    this.waitForPw = false;
+    this.waitForPassword = false;
     this.scan({ header: 'Encryption-Password', value: pw });
   }
 
@@ -312,7 +315,7 @@ class Upload {
     }
 
     if (uploadResult === 'rejected') {
-      this.waitForPw = true;
+      this.waitForPassword = true;
       if (decryptResult === 'rejected') {
         return {
           status: uploadResult,
@@ -325,13 +328,13 @@ class Upload {
     if (uploadResult === 'encrypted') {
       // needs pw, isDecrypting, isScanning
       if (
-        !this.waitForPw &&
+        !this.waitForPassword &&
         (decryptResult === null || decryptResult === 'pending')
       ) {
         return { status: 'decrypting', message: msg || 'Decrypting file' };
       }
       if (decryptResult === 'rejected') {
-        this.waitForPw = true;
+        this.waitForPassword = true;
         return { status: uploadResult, message: msg || 'Incorrect password' };
       }
       return {


### PR DESCRIPTION
Includes:

- upgrading jest 24.x
- upgrading eslint 5.x
- upgrading eslint-config-availity 4.x
- refactor to use jest.config.js and babel.config.js
- fix all linter issues