### PR TITLE
fix: append function is not defined for ie and edge mobile

### DIFF
--- a/packages/native-form/index.js
+++ b/packages/native-form/index.js
@@ -32,6 +32,7 @@ export default (
     .join('');
 
   form.insertAdjacentHTML('beforeend', fields);
-  document.body.append(form);
+  // eslint-disable-next-line unicorn/prefer-node-append
+  document.body.appendChild(form);
   form.submit();
 };


### PR DESCRIPTION
Replaced `append` method with native DOM function `appendChild` as the `append` method is not native to IE and Edge Mobile yet.

https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/append