### PR TITLE
feat(analytics-core): added config object with attribute prefix and r…

### DIFF
--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -19,7 +19,18 @@ For page tracking to be used, `startPageTracking` and `stopPageTracking` functio
 When `true`, "autoTrack" will be enabled which will automatically log
 
 ```javascript
-  new AvAnalytics(plugins, promise, pageTracking, autoTrack);
+  new AvAnalytics(plugins, promise, pageTracking, autoTrack, options);
+```
+
+### Options
+- **attributePrefix** string. Overrides the default prefix for getting attributes.
+- **recursive** boolean. If `true`, will add on all attributes from the clicke/focused node up to the root element. It requires one attribute to have contain `action`.
+
+ Example using the `recursive` option ( Will add all 3 attributes when the `anchor` tag is clicked. If the container is clicked nothing will happen ):
+```html
+<div class="container" data-analytics-app-name="app">
+    <a href="#" data-analytics-action="click" data-analytics-event-name="linking">Click me!</a>
+</div>
 ```
 
 ## Plugins

--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -92,6 +92,10 @@ export default class AvAnalytics {
     !isValidEventTypeOnTarget(event);
 
   getAnalyticAttrs = elem => {
+    if(!elem.attributes) {
+      return {};
+    }
+
     const attrs = [...elem.attributes];
     const analyticAttrs = {};
 

--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -69,20 +69,26 @@ export default class AvAnalytics {
 
         analyticAttrs = { ...analyticAttrs, ...attrs };
 
-        analyticAttrs.action = analyticAttrs.action || event.type;
+        // To consider using the element it has to have analytics attrs
+        if (Object.keys(attrs).length > 0) {
+          analyticAttrs.elemId =
+            pth.getAttribute('id') || pth.getAttribute('name');
+        }
       });
     } else {
       analyticAttrs = this.getAnalyticAttrs(target);
-      analyticAttrs.elemId =
-        analyticAttrs.elemId ||
-        target.getAttribute('id') ||
-        target.getAttribute('name');
-      analyticAttrs.action = analyticAttrs.action || event.type;
     }
 
     if (!Object.keys(analyticAttrs).length > 0) {
       return;
     }
+
+    analyticAttrs.action = analyticAttrs.action || event.type;
+    analyticAttrs.elemId =
+      analyticAttrs.elemId ||
+      target.getAttribute('id') ||
+      target.getAttribute('name');
+
     this.trackEvent(analyticAttrs);
   };
 
@@ -103,7 +109,9 @@ export default class AvAnalytics {
       for (let i = attrs.length - 1; i >= 0; i--) {
         const { name } = attrs[i];
         if (name.indexOf(`${this.attributePrefix}-`) === 0) {
-          const camelName = camelCase(name.slice(15));
+          const camelName = camelCase(
+            name.slice(this.attributePrefix.length + 1)
+          );
           analyticAttrs[camelName] = elem.getAttribute(name);
         }
       }

--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -92,7 +92,7 @@ export default class AvAnalytics {
     !isValidEventTypeOnTarget(event);
 
   getAnalyticAttrs = elem => {
-    if(!elem.attributes) {
+    if (!elem.attributes) {
       return {};
     }
 

--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -27,7 +27,7 @@ const camelCase = str =>
  * Polyfill for [`Event.composedPath()`][1].
  * https://gist.github.com/kleinfreund/e9787d73776c0e3750dcfcdc89f100ec
  */
-const getComposedPath = (node) => {
+const getComposedPath = node => {
   let parent;
   if (node.parentNode) {
     parent = node.parentNode;
@@ -42,7 +42,7 @@ const getComposedPath = (node) => {
   }
 
   return [node];
-}
+};
 
 export default class AvAnalytics {
   constructor(
@@ -101,7 +101,10 @@ export default class AvAnalytics {
       analyticAttrs = this.getAnalyticAttrs(target);
     }
 
-    if (!Object.keys(analyticAttrs).length > 0 || (this.recursive && !analyticAttrs.action)) {
+    if (
+      !Object.keys(analyticAttrs).length > 0 ||
+      (this.recursive && !analyticAttrs.action)
+    ) {
       return;
     }
 

--- a/packages/analytics-core/src/tests/analytics.test.js
+++ b/packages/analytics-core/src/tests/analytics.test.js
@@ -32,6 +32,15 @@ describe('AvAnalytics', () => {
     expect(mockAvAnalytics.plugins).toEqual([plugin]);
   });
 
+  test('AvAnalytics should use custom configs', () => {
+    mockAvAnalytics = new AvAnalytics([], Promise, true, true, {
+      attributePrefix: 'some-attr',
+      recursive: true,
+    });
+    expect(mockAvAnalytics.attributePrefix).toBe('some-attr');
+    expect(mockAvAnalytics.recursive).toBe(true);
+  });
+
   describe('setPageTracking', () => {
     beforeEach(() => {
       const plugins = [makePlugin()];


### PR DESCRIPTION
Added in config object to the end of the `avAnalytics` constructor for any additional options we pass in.

Two new ones were add for this case:
`recursive` - if true the targeted element will traverse through all the of the dom elements it was nested in and pull out all the attributes that match the attributePrefix. It will start from top to bottom so any attributes can be overridden at the child level.

`attributePrefix` - If anyone wants to change the attribute prefix used to stripe the attributes off they can here. Could be useful if there are multiple analytics trackers or an app that previously used `angular-analytics` can easily be updated with this version overriding the attribute prefix.