### PR TITLE
fix(resolve-url): make ie11 compat

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@availity/resolve-url": "^1.0.0",
-    "is-absolute-url": "^3.0.0",
     "qs": "^6.5.2"
   },
   "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"

--- a/packages/resolve-url/README.md
+++ b/packages/resolve-url/README.md
@@ -2,8 +2,8 @@
 
 > Resolve URLs to absolute URI/IRI.
 
-This library is a small wrapper around [relative-to-absolute-iri
-](https://github.com/rubensworks/relative-to-absolute-iri.js) which resolve srelative IRIs to absolute IRIs given a base IRI, conforming to [RFC3986}(https://www.ietf.org/rfc/rfc3986.txt).
+This library resolves relative IRIs to absolute IRIs given a base IRI, conforming to \[RFC3986}(<https://www.ietf.org/rfc/rfc3986.txt>). The code was borrowed from  [relative-to-absolute-iri
+](https://github.com/rubensorks/relative-to-absolute-iri.js). There is an open issue to make the library compatible with IE11:  [Issue #5](https://github.com/rubensworks/relative-to-absolute-iri.js/issues/5)
 
 ## Installation
 
@@ -36,7 +36,7 @@ resolveUrl({relative: '/a/b'})
 ```
 
 > The following examples were adapted from [relative-to-absolute-iri
-](https://github.com/rubensworks/relative-to-absolute-iri.js)
+> ](https://github.com/rubensworks/relative-to-absolute-iri.js)
 
 ### Hashes
 
@@ -64,7 +64,6 @@ resolve('//abc', 'http://base.org/'); // Outputs 'http://abc'
 
 ### Root-Relative
 
-
 Relative URIs that starts with a `/` erase the path of the base IRI.
 
 ```javascript
@@ -83,5 +82,5 @@ resolve('xyz', 'http://aa/././a'); // Outputs 'http://aa/xyz'
 
 ## Notes
 
-- `URI` - Uniform Resource Identifier allows ASCII characters
-- `IRI` - Internationalized Resource Identifier allows Unicode typeset
+-   `URI` - Uniform Resource Identifier allows ASCII characters
+-   `IRI` - Internationalized Resource Identifier allows Unicode typeset

--- a/packages/resolve-url/is-absolute-url.js
+++ b/packages/resolve-url/is-absolute-url.js
@@ -1,0 +1,10 @@
+// Borrowed from https://github.com/sindresorhus/is-absolute-url to make IE11 compatible
+const isAbsoluteUrl = url => {
+  if (typeof url !== 'string') {
+    throw new TypeError(`Expected a \`string\`, got \`${typeof url}\``);
+  }
+
+  return /^[a-z][a-z\d+.-]*:/.test(url);
+};
+
+export default isAbsoluteUrl;

--- a/packages/resolve-url/is-absolute-url.test.js
+++ b/packages/resolve-url/is-absolute-url.test.js
@@ -1,0 +1,21 @@
+// From https://github.com/sindresorhus/is-absolute-url/blob/master/test.js
+import isAbsoluteUrl from './is-absolute-url';
+
+describe('is-absolute-url', () => {
+  it('should be absolute url', () => {
+    expect(isAbsoluteUrl('http://sindresorhus.com')).toBeTruthy();
+    expect(isAbsoluteUrl('https://sindresorhus.com')).toBeTruthy();
+    expect(isAbsoluteUrl('file://sindresorhus.com')).toBeTruthy();
+    expect(isAbsoluteUrl('mailto:someone@example.com')).toBeTruthy();
+    expect(
+      isAbsoluteUrl('data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D')
+    ).toBeTruthy();
+  });
+
+  it('should be relative url', () => {
+    expect(isAbsoluteUrl('//sindresorhus.com')).toBeFalsy();
+    expect(isAbsoluteUrl('/foo/bar')).toBeFalsy();
+    expect(isAbsoluteUrl('foo/bar')).toBeFalsy();
+    expect(isAbsoluteUrl('foo')).toBeFalsy();
+  });
+});

--- a/packages/resolve-url/package.json
+++ b/packages/resolve-url/package.json
@@ -8,11 +8,7 @@
     "relative"
   ],
   "author": "Rob McGuinness <rob.mcguinness@availity.com>",
-  "license": "UNLICENSED",
-  "dependencies": {
-    "is-absolute-url": "^3.0.0",
-    "relative-to-absolute-iri": "^1.0.2"
-  },
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/resolve-url/relative-to-absolute.js
+++ b/packages/resolve-url/relative-to-absolute.js
@@ -1,0 +1,251 @@
+// Borrowed from  https://github.com/rubensworks/relative-to-absolute-iri.js but refactored to work with IE11.
+function isCharacterAllowedAfterRelativePathSegment(character) {
+  return (
+    !character || character === '#' || character === '?' || character === '/'
+  );
+}
+
+/**
+ * Remove dot segments from the given path,
+ * as described in https://www.ietf.org/rfc/rfc3986.txt (page 32).
+ * @param {string} path An IRI path.
+ * @return {string} A path, will always start with a '/'.
+ */
+export function removeDotSegments(path) {
+  // Prepare a buffer with segments between each '/.
+  // Each segment represents an array of characters.
+  const segmentBuffers = [];
+
+  let i = 0;
+  while (i < path.length) {
+    // Remove '/.' or '/..'
+    switch (path[i]) {
+      case '/':
+        if (path[i + 1] === '.') {
+          if (path[i + 2] === '.') {
+            // Append the remaining path as-is if we find an invalid character after the '.'
+            if (!isCharacterAllowedAfterRelativePathSegment(path[i + 3])) {
+              segmentBuffers[segmentBuffers.length - 1].push(path.substr(i));
+              i = path.length;
+              break;
+            }
+
+            // Go to parent directory,
+            // so we remove a parent segment
+            segmentBuffers.pop();
+
+            // Ensure that we end with a slash if there is a trailing '/..'
+            if (!path[i + 3]) {
+              segmentBuffers.push([]);
+            }
+
+            i += 3;
+          } else {
+            // Append the remaining path as-is if we find an invalid character after the '.'
+            if (!isCharacterAllowedAfterRelativePathSegment(path[i + 2])) {
+              segmentBuffers[segmentBuffers.length - 1].push(path.substr(i));
+              i = path.length;
+              break;
+            }
+
+            // Ensure that we end with a slash if there is a trailing '/.'
+            if (!path[i + 2]) {
+              segmentBuffers.push([]);
+            }
+
+            // Go to the current directory,
+            // so we do nothing
+            i += 2;
+          }
+        } else {
+          // Start a new segment
+          segmentBuffers.push([]);
+          i += 1;
+        }
+        break;
+      case '#':
+      case '?':
+        // Query and fragment string should be appended unchanged
+        if (!segmentBuffers.length > 0) {
+          segmentBuffers.push([]);
+        }
+        segmentBuffers[segmentBuffers.length - 1].push(path.substr(i));
+        // Break the while loop
+        i = path.length;
+        break;
+      default:
+        // Not a special character, just append it to our buffer
+        if (!segmentBuffers.length > 0) {
+          segmentBuffers.push([]);
+        }
+        segmentBuffers[segmentBuffers.length - 1].push(path[i]);
+        i += 1;
+        break;
+    }
+  }
+
+  return `/${segmentBuffers.map(buffer => buffer.join('')).join('/')}`;
+}
+
+/**
+ * Removes dot segments of the given IRI.
+ * @param {string} iri An IRI (or part of IRI).
+ * @param {number} colonPosition The position of the first ':' in the IRI.
+ * @return {string} The IRI where dot segments were removed.
+ */
+export function removeDotSegmentsOfPath(iri, colonPosition) {
+  // Determine where we should start looking for the first '/' that indicates the start of the path
+  let searchOffset = colonPosition + 1;
+  if (colonPosition >= 0) {
+    if (iri[colonPosition + 1] === '/' && iri[colonPosition + 2] === '/') {
+      searchOffset = colonPosition + 3;
+    }
+  } else if (iri[0] === '/' && iri[1] === '/') {
+    searchOffset = 2;
+  }
+
+  // Determine the path
+  const pathSeparator = iri.indexOf('/', searchOffset);
+  if (pathSeparator < 0) {
+    return iri;
+  }
+  const base = iri.substr(0, pathSeparator);
+  const path = iri.substr(pathSeparator);
+
+  // Remove dot segments from the path
+  return base + removeDotSegments(path);
+}
+
+/**
+ * Convert the given relative IRI to an absolute IRI
+ * by taking into account the given optional baseIRI.
+ *
+ * @param {string} relativeIRI The relative IRI to convert to an absolute IRI.
+ * @param {string} baseIRI The optional base IRI.
+ * @return {string} an absolute IRI.
+ */
+export function resolve(relativeIRI, baseIRI) {
+  baseIRI = baseIRI || '';
+  const baseFragmentPos = baseIRI.indexOf('#');
+
+  // Ignore any fragments in the base IRI
+  if (baseFragmentPos > 0) {
+    baseIRI = baseIRI.substr(0, baseFragmentPos);
+  }
+
+  // Convert empty value directly to base IRI
+  if (!relativeIRI.length > 0) {
+    return baseIRI;
+  }
+
+  // If the value starts with a query character, concat directly (but strip the existing query)
+  if (relativeIRI.startsWith('?')) {
+    const baseQueryPos = baseIRI.indexOf('?');
+    if (baseQueryPos > 0) {
+      baseIRI = baseIRI.substr(0, baseQueryPos);
+    }
+    return baseIRI + relativeIRI;
+  }
+
+  // If the value starts with a fragment character, concat directly
+  if (relativeIRI.startsWith('#')) {
+    return baseIRI + relativeIRI;
+  }
+
+  // Ignore baseIRI if it is empty
+  if (!baseIRI.length > 0) {
+    return removeDotSegmentsOfPath(relativeIRI, relativeIRI.indexOf(':'));
+  }
+
+  // Ignore baseIRI if the value is absolute
+  const valueColonPos = relativeIRI.indexOf(':');
+  if (valueColonPos >= 0) {
+    return removeDotSegmentsOfPath(relativeIRI, valueColonPos);
+  }
+
+  // At this point, the baseIRI MUST be absolute, otherwise we error
+  const baseColonPos = baseIRI.indexOf(':');
+  if (baseColonPos < 0) {
+    throw new Error(
+      `Found invalid baseIRI '${baseIRI}' for value '${relativeIRI}'`
+    );
+  }
+
+  const baseIRIScheme = baseIRI.substr(0, baseColonPos + 1);
+  // Inherit the baseIRI scheme if the value starts with '//'
+  if (relativeIRI.indexOf('//') === 0) {
+    return baseIRIScheme + removeDotSegmentsOfPath(relativeIRI, valueColonPos);
+  }
+
+  // Check cases where '://' occurs in the baseIRI, and where there is no '/' after a ':' anymore.
+  let baseSlashAfterColonPos;
+  if (baseIRI.indexOf('//', baseColonPos) === baseColonPos + 1) {
+    // If there is no additional '/' after the '//'.
+    baseSlashAfterColonPos = baseIRI.indexOf('/', baseColonPos + 3);
+    if (baseSlashAfterColonPos < 0) {
+      // If something other than a '/' follows the '://', append the value after a '/',
+      // otherwise, prefix the value with only the baseIRI scheme.
+      if (baseIRI.length > baseColonPos + 3) {
+        return `${baseIRI}/${removeDotSegmentsOfPath(
+          relativeIRI,
+          valueColonPos
+        )}`;
+      }
+
+      return (
+        baseIRIScheme + removeDotSegmentsOfPath(relativeIRI, valueColonPos)
+      );
+    }
+  } else {
+    // If there is not even a single '/' after the ':'
+    baseSlashAfterColonPos = baseIRI.indexOf('/', baseColonPos + 1);
+    // Always true: baseSlashAfterColonPos < 0
+    // If something other than a '/' follows the ':', append the value after a '/',
+    // otherwise, prefix the value with only the baseIRI scheme.
+    if (baseIRI.length > baseColonPos + 1) {
+      return `${baseIRI}/${removeDotSegmentsOfPath(
+        relativeIRI,
+        valueColonPos
+      )}`;
+    }
+
+    return baseIRIScheme + removeDotSegmentsOfPath(relativeIRI, valueColonPos);
+  }
+
+  // If the value starts with a '/', then prefix it with everything before the first effective slash of the base IRI.
+  if (relativeIRI.indexOf('/') === 0) {
+    return (
+      baseIRI.substr(0, baseSlashAfterColonPos) + removeDotSegments(relativeIRI)
+    );
+  }
+
+  let baseIRIPath = baseIRI.substr(baseSlashAfterColonPos);
+  const baseIRILastSlashPos = baseIRIPath.lastIndexOf('/');
+
+  // Ignore everything after the last '/' in the baseIRI path
+  if (
+    baseIRILastSlashPos >= 0 &&
+    baseIRILastSlashPos < baseIRIPath.length - 1
+  ) {
+    baseIRIPath = baseIRIPath.substr(0, baseIRILastSlashPos + 1);
+    // Also remove the first character of the relative path if it starts with '.' (and not '..' or './')
+    // This change is only allowed if there is something else following the path
+    if (
+      relativeIRI[0] === '.' &&
+      relativeIRI[1] !== '.' &&
+      relativeIRI[1] !== '/' &&
+      relativeIRI[2]
+    ) {
+      relativeIRI = relativeIRI.substr(1);
+    }
+  }
+
+  // Prefix the value with the baseIRI path where
+  relativeIRI = baseIRIPath + relativeIRI;
+
+  // Remove dot segment from the IRI
+  relativeIRI = removeDotSegments(relativeIRI);
+
+  // Prefix our transformed value with the part of the baseIRI until the first '/' after the first ':'.
+  return baseIRI.substr(0, baseSlashAfterColonPos) + relativeIRI;
+}

--- a/packages/resolve-url/relative-to-absolute.test.js
+++ b/packages/resolve-url/relative-to-absolute.test.js
@@ -1,0 +1,554 @@
+import { removeDotSegments, resolve } from './relative-to-absolute';
+
+describe('#resolve', () => {
+  it('create an IRI from an absolute IRI when no baseIRI is given', () => {
+    expect(resolve('http://example.org/')).toEqual('http://example.org/');
+  });
+
+  it('create an IRI from an absolute IRI when the baseIRI is empty', () => {
+    expect(resolve('http://example.org/', '')).toEqual('http://example.org/');
+  });
+
+  it('create an IRI from an absolute IRI when a baseIRI is given', () => {
+    expect(resolve('http://example.org/', 'http://base.org/')).toEqual(
+      'http://example.org/'
+    );
+  });
+
+  it('create an IRI from the baseIRI when given value is empty', () => {
+    expect(resolve('', 'http://base.org/')).toEqual('http://base.org/');
+  });
+
+  it('create an IRI from a relative IRI when no baseIRI is given', () => {
+    expect(resolve('abc')).toEqual('abc');
+  });
+
+  it('create an IRI from a relative IRI without dot segments when no baseIRI is given', () => {
+    expect(resolve('http://abc/../../')).toEqual('http://abc/');
+  });
+
+  it('create an IRI from a relative IRI when a baseIRI is given', () => {
+    expect(resolve('abc', 'http://base.org/')).toEqual('http://base.org/abc');
+  });
+
+  it('create an IRI from a relative IRI when a baseIRI is given and ignore the baseIRI fragment', () => {
+    expect(resolve('abc', 'http://base.org/#frag')).toEqual(
+      'http://base.org/abc'
+    );
+  });
+
+  it('create an IRI from a hash', () => {
+    expect(resolve('#abc', 'http://base.org/')).toEqual('http://base.org/#abc');
+  });
+
+  it('create an IRI and ignore the baseIRI if the value contains a colon', () => {
+    expect(resolve('http:abc', 'http://base.org/')).toEqual('http:abc');
+  });
+
+  it('create an IRI and ignore the baseIRI if the value contains a colon, and remove dot segments', () => {
+    expect(resolve('http://abc/../../', 'http://base.org/')).toEqual(
+      'http://abc/'
+    );
+  });
+
+  it('error for a non-absolute baseIRI', () => {
+    expect(() => resolve('abc', 'def')).toThrow();
+  });
+
+  it('create an IRI that has the baseIRI scheme if the value starts with //', () => {
+    expect(resolve('//abc', 'http://base.org/')).toEqual('http://abc');
+  });
+
+  it('create an IRI from a baseIRI without a / in the path', () => {
+    expect(resolve('abc', 'http://base.org')).toEqual('http://base.org/abc');
+  });
+
+  it('create an IRI from a baseIRI without a / in the path, and remove dot segments', () => {
+    expect(resolve('abc/./', 'http://base.org')).toEqual(
+      'http://base.org/abc/'
+    );
+  });
+
+  it('create an IRI from the baseIRI scheme when the baseIRI contains only ://', () => {
+    expect(resolve('abc', 'http://')).toEqual('http:abc');
+  });
+
+  it('create an IRI from the baseIRI scheme when the baseIRI contains only ://, and remove dot segments', () => {
+    expect(resolve('abc/./', 'http://')).toEqual('http:abc/');
+  });
+
+  it('create an IRI from the baseIRI if something other than a / follows the :', () => {
+    expect(resolve('abc', 'http:a')).toEqual('http:a/abc');
+  });
+
+  it('create an IRI from the baseIRI if something other than a / follows the :, and remove dot segments', () => {
+    expect(resolve('abc/./', 'http:a')).toEqual('http:a/abc/');
+  });
+
+  it('create an IRI from the baseIRI scheme if nothing follows the :', () => {
+    expect(resolve('abc', 'http:')).toEqual('http:abc');
+  });
+
+  it('create an IRI from the baseIRI scheme if nothing follows the :, and remove dot segments', () => {
+    expect(resolve('abc/./', 'http:')).toEqual('http:abc/');
+  });
+
+  it('create an IRI from an absolute path and ignore the path from the base IRI', () => {
+    expect(resolve('/abc/def/', 'http://base.org/123/456/')).toEqual(
+      'http://base.org/abc/def/'
+    );
+  });
+
+  it('create an IRI from a baseIRI with http:// and ignore everything after the last slash', () => {
+    expect(resolve('xyz', 'http://aa/a')).toEqual('http://aa/xyz');
+  });
+
+  it('create an IRI from a baseIRI with http:// and collapse parent paths', () => {
+    expect(resolve('xyz', 'http://aa/parent/parent/../../a')).toEqual(
+      'http://aa/xyz'
+    );
+  });
+
+  it('create an IRI from a baseIRI with http:// and remove current-dir paths', () => {
+    expect(resolve('xyz', 'http://aa/././a')).toEqual('http://aa/xyz');
+  });
+
+  it('create an IRI from a baseIRI and .', () => {
+    expect(resolve('.', 'http://aa/')).toEqual('http://aa/');
+  });
+
+  it('create an IRI from a baseIRI and ..', () => {
+    expect(resolve('..', 'http://aa/b/')).toEqual('http://aa/');
+  });
+
+  it('create an IRI from a baseIRI and ../', () => {
+    expect(resolve('../', 'http://aa/b/')).toEqual('http://aa/');
+  });
+
+  it('create an IRI from a baseIRI without ending slash and ..', () => {
+    expect(resolve('..', 'http://aa/b')).toEqual('http://aa/');
+  });
+
+  it('create an IRI from a baseIRI without ending slash and ../', () => {
+    expect(resolve('../', 'http://aa/b')).toEqual('http://aa/');
+  });
+
+  it('create an IRI from a baseIRI without ending slash and ?a=b', () => {
+    expect(resolve('?a=b', 'http://abc/def/ghi')).toEqual(
+      'http://abc/def/ghi?a=b'
+    );
+  });
+
+  it('create an IRI from a baseIRI without ending slash and .?a=b', () => {
+    expect(resolve('.?a=b', 'http://abc/def/ghi')).toEqual(
+      'http://abc/def/?a=b'
+    );
+  });
+
+  it('create an IRI from a baseIRI without ending slash and ..?a=b', () => {
+    expect(resolve('..?a=b', 'http://abc/def/ghi')).toEqual('http://abc/?a=b');
+  });
+
+  it('create an IRI from a baseIRI without ending slash and xyz', () => {
+    expect(resolve('xyz', 'http://abc/d:f/ghi')).toEqual('http://abc/d:f/xyz');
+  });
+
+  it('create an IRI from a baseIRI without ending slash and ./xyz', () => {
+    expect(resolve('./xyz', 'http://abc/d:f/ghi')).toEqual(
+      'http://abc/d:f/xyz'
+    );
+  });
+
+  it('create an IRI from a baseIRI without ending slash and ../xyz', () => {
+    expect(resolve('../xyz', 'http://abc/d:f/ghi')).toEqual('http://abc/xyz');
+  });
+
+  it('create an IRI from a relative IRI with : and ignore the baseIRI', () => {
+    expect(resolve('g:h', 'file:///a/bb/ccc/d;p?q')).toEqual('g:h');
+  });
+
+  it('create an IRI from a simple relative IRI and complex baseIRI', () => {
+    expect(resolve('g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g'
+    );
+  });
+
+  it('create an IRI from a ./g relative IRI and complex baseIRI', () => {
+    expect(resolve('./g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g'
+    );
+  });
+
+  it('create an IRI from a g/ relative IRI and complex baseIRI', () => {
+    expect(resolve('g/', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g/'
+    );
+  });
+
+  it('create an IRI from a /g relative IRI and complex baseIRI', () => {
+    expect(resolve('/g', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///g');
+  });
+
+  it('create an IRI from a //g relative IRI and complex baseIRI', () => {
+    expect(resolve('//g', 'file:///a/bb/ccc/d;p?q')).toEqual('file://g');
+  });
+
+  it('create an IRI from a ?y relative IRI and complex baseIRI', () => {
+    expect(resolve('?y', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/d;p?y'
+    );
+  });
+
+  it('create an IRI from a g?y relative IRI and complex baseIRI', () => {
+    expect(resolve('g?y', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g?y'
+    );
+  });
+
+  it('create an IRI from a #s relative IRI and complex baseIRI', () => {
+    expect(resolve('#s', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/d;p?q#s'
+    );
+  });
+
+  it('create an IRI from a g#s relative IRI and complex baseIRI', () => {
+    expect(resolve('g#s', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g#s'
+    );
+  });
+
+  it('create an IRI from a g?y#s relative IRI and complex baseIRI', () => {
+    expect(resolve('g?y#s', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g?y#s'
+    );
+  });
+
+  it('create an IRI from a ;x relative IRI and complex baseIRI', () => {
+    expect(resolve(';x', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/;x'
+    );
+  });
+
+  it('create an IRI from a g;x relative IRI and complex baseIRI', () => {
+    expect(resolve('g;x', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g;x'
+    );
+  });
+
+  it('create an IRI from a g;x?y#s relative IRI and complex baseIRI', () => {
+    expect(resolve('g;x?y#s', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g;x?y#s'
+    );
+  });
+
+  it('create an IRI from an empty relative IRI and complex baseIRI', () => {
+    expect(resolve('', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/d;p?q'
+    );
+  });
+
+  it('create an IRI from a . relative IRI and complex baseIRI', () => {
+    expect(resolve('.', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/bb/ccc/');
+  });
+
+  it('create an IRI from a ./ relative IRI and complex baseIRI', () => {
+    expect(resolve('./', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/'
+    );
+  });
+
+  it('create an IRI from a .. relative IRI and complex baseIRI', () => {
+    expect(resolve('..', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/bb/');
+  });
+
+  it('create an IRI from a ../ relative IRI and complex baseIRI', () => {
+    expect(resolve('../', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/bb/');
+  });
+
+  it('create an IRI from a ../g relative IRI and complex baseIRI', () => {
+    expect(resolve('../g', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/bb/g');
+  });
+
+  it('create an IRI from a ../.. relative IRI and complex baseIRI', () => {
+    expect(resolve('../..', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/');
+  });
+
+  it('create an IRI from a ../../ relative IRI and complex baseIRI', () => {
+    expect(resolve('../../', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/');
+  });
+
+  it('create an IRI from a ../../g relative IRI and complex baseIRI', () => {
+    expect(resolve('../../g', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///a/g');
+  });
+
+  it('create an IRI from a ../../.. relative IRI and complex baseIRI', () => {
+    expect(resolve('../../..', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///');
+  });
+
+  it('create an IRI from a ../../../ relative IRI and complex baseIRI', () => {
+    expect(resolve('../../../', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///');
+  });
+
+  it('create an IRI from a ../../../g relative IRI and complex baseIRI', () => {
+    expect(resolve('../../../g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///g'
+    );
+  });
+
+  it('create an IRI from a ../../../../g relative IRI and complex baseIRI', () => {
+    expect(resolve('../../../../g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///g'
+    );
+  });
+
+  it('create an IRI from a /./g relative IRI and complex baseIRI', () => {
+    expect(resolve('/./g', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///g');
+  });
+
+  it('create an IRI from a /../g relative IRI and complex baseIRI', () => {
+    expect(resolve('/../g', 'file:///a/bb/ccc/d;p?q')).toEqual('file:///g');
+  });
+
+  it('create an IRI from a g. relative IRI and complex baseIRI', () => {
+    expect(resolve('g.', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g.'
+    );
+  });
+
+  it('create an IRI from a .g relative IRI and complex baseIRI', () => {
+    expect(resolve('.g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/.g'
+    );
+  });
+
+  it('create an IRI from a g.. relative IRI and complex baseIRI', () => {
+    expect(resolve('g..', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g..'
+    );
+  });
+
+  it('create an IRI from a ..g relative IRI and complex baseIRI', () => {
+    expect(resolve('..g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/..g'
+    );
+  });
+
+  it('create an IRI from a ./../g relative IRI and complex baseIRI', () => {
+    expect(resolve('./../g', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/g'
+    );
+  });
+
+  it('create an IRI from a ./g/. relative IRI and complex baseIRI', () => {
+    expect(resolve('./g/.', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g/'
+    );
+  });
+
+  it('create an IRI from a g/./h relative IRI and complex baseIRI', () => {
+    expect(resolve('g/./h', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g/h'
+    );
+  });
+
+  it('create an IRI from a g/../h relative IRI and complex baseIRI', () => {
+    expect(resolve('g/../h', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/h'
+    );
+  });
+
+  it('create an IRI from a g;x=1/./y relative IRI and complex baseIRI', () => {
+    expect(resolve('g;x=1/./y', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g;x=1/y'
+    );
+  });
+
+  it('create an IRI from a g;x=1/../y relative IRI and complex baseIRI', () => {
+    expect(resolve('g;x=1/../y', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/y'
+    );
+  });
+
+  it('create an IRI from a g?y/./x relative IRI and complex baseIRI', () => {
+    expect(resolve('g?y/./x', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g?y/./x'
+    );
+  });
+
+  it('create an IRI from a g?y/../x relative IRI and complex baseIRI', () => {
+    expect(resolve('g?y/../x', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g?y/../x'
+    );
+  });
+
+  it('create an IRI from a g#s/./x relative IRI and complex baseIRI', () => {
+    expect(resolve('g#s/./x', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g#s/./x'
+    );
+  });
+
+  it('create an IRI from a g#s/../x relative IRI and complex baseIRI', () => {
+    expect(resolve('g#s/../x', 'file:///a/bb/ccc/d;p?q')).toEqual(
+      'file:///a/bb/ccc/g#s/../x'
+    );
+  });
+
+  it('create an IRI from a http:g relative IRI and complex baseIRI', () => {
+    expect(resolve('http:g', 'file:///a/bb/ccc/d;p?q')).toEqual('http:g');
+  });
+
+  it('create an IRI from a //example.org/.././useless/../../scheme-relative relative IRI and complex baseIRI', () => {
+    expect(
+      resolve(
+        '//example.org/.././useless/../../scheme-relative',
+        'http://example.com/some/deep/directory/and/file#with-a-fragment'
+      )
+    ).toEqual('http://example.org/scheme-relative');
+  });
+});
+
+describe('#removeDotSegments', () => {
+  it('should handle a path without slashes', () => {
+    expect(removeDotSegments('abc')).toEqual('/abc');
+  });
+
+  it('should handle a path with a single slash', () => {
+    expect(removeDotSegments('abc/')).toEqual('/abc/');
+  });
+
+  it('should handle a path with a single slash at the start', () => {
+    expect(removeDotSegments('/abc')).toEqual('/abc');
+  });
+
+  it('should handle a path with a slash at the start and end', () => {
+    expect(removeDotSegments('/abc/')).toEqual('/abc/');
+  });
+
+  it('should handle a /.', () => {
+    expect(removeDotSegments('/.')).toEqual('/');
+  });
+
+  it('should handle a /..', () => {
+    expect(removeDotSegments('/..')).toEqual('/');
+  });
+
+  it('should handle a parent directory', () => {
+    expect(removeDotSegments('/abc/..')).toEqual('/');
+  });
+
+  it('should handle a current directory', () => {
+    expect(removeDotSegments('/abc/.')).toEqual('/abc/');
+  });
+
+  it('should handle an inbetween parent directory', () => {
+    expect(removeDotSegments('/abc/../def/')).toEqual('/def/');
+  });
+
+  it('should handle another inbetween parent directory', () => {
+    expect(removeDotSegments('mid/content=5/../6')).toEqual('/mid/6');
+  });
+
+  it('should handle an inbetween current directory', () => {
+    expect(removeDotSegments('/abc/./def/')).toEqual('/abc/def/');
+  });
+
+  it('should handle multiple parent directories', () => {
+    expect(removeDotSegments('/abc/def/ghi/../..')).toEqual('/abc/');
+  });
+
+  it('should handle multiple current directories', () => {
+    expect(removeDotSegments('/abc/././.')).toEqual('/abc/');
+  });
+
+  it('should handle mixed current and parent directories', () => {
+    expect(removeDotSegments('/abc/def/./ghi/../..')).toEqual('/abc/');
+  });
+
+  it('should handle another mixed current and parent directories', () => {
+    expect(removeDotSegments('/a/b/c/./../../g')).toEqual('/a/g');
+  });
+
+  it('should not modify fragments', () => {
+    expect(removeDotSegments('/abc#abcdef')).toEqual('/abc#abcdef');
+  });
+
+  it('should not modify paths in fragments', () => {
+    expect(removeDotSegments('/abc#a/bc/def')).toEqual('/abc#a/bc/def');
+  });
+
+  it('should not modify current paths in fragments', () => {
+    expect(removeDotSegments('/abc#a/./bc/def')).toEqual('/abc#a/./bc/def');
+  });
+
+  it('should not modify parent paths in fragments', () => {
+    expect(removeDotSegments('/abc#a/../bc/def')).toEqual('/abc#a/../bc/def');
+  });
+
+  it('should not modify queries', () => {
+    expect(removeDotSegments('/abc?abcdef')).toEqual('/abc?abcdef');
+  });
+
+  it('should not modify paths in queries', () => {
+    expect(removeDotSegments('/abc?a/bc/def')).toEqual('/abc?a/bc/def');
+  });
+
+  it('should not modify current paths in queries', () => {
+    expect(removeDotSegments('/abc?a/./bc/def')).toEqual('/abc?a/./bc/def');
+  });
+
+  it('should not modify parent paths in queries', () => {
+    expect(removeDotSegments('/abc?a/../bc/def')).toEqual('/abc?a/../bc/def');
+  });
+
+  it('should handle mixed current and parent directories with a fragment', () => {
+    expect(removeDotSegments('/abc/def/./ghi/../..#abc')).toEqual('/abc#abc');
+  });
+
+  it('should handle a fragment without another path', () => {
+    expect(removeDotSegments('#abc')).toEqual('/#abc');
+  });
+
+  it('should not remove zero-length segments', () => {
+    expect(removeDotSegments('/abc//def/')).toEqual('/abc//def/');
+  });
+
+  it('should be able to parent into zero-length segments', () => {
+    expect(removeDotSegments('/abc//def//../')).toEqual('/abc//def/');
+  });
+
+  it('should be able to current over zero-length segments', () => {
+    expect(removeDotSegments('/abc//def//./')).toEqual('/abc//def//');
+  });
+
+  it('should resolve a query against non-/', () => {
+    expect(removeDotSegments('/def/ghi?a=b')).toEqual('/def/ghi?a=b');
+  });
+
+  it('should resolve a query against /', () => {
+    expect(removeDotSegments('/def/?a=b')).toEqual('/def/?a=b');
+  });
+
+  it('should resolve a .. and query', () => {
+    expect(removeDotSegments('/def/..?a=b')).toEqual('/?a=b');
+  });
+
+  it('should just append a .g after a slash', () => {
+    expect(removeDotSegments('/a/bb/ccc/.g')).toEqual('/a/bb/ccc/.g');
+  });
+
+  it('should just append a g. after a slash', () => {
+    expect(removeDotSegments('/a/bb/ccc/g.')).toEqual('/a/bb/ccc/g.');
+  });
+
+  it('should just append a ..g after a slash', () => {
+    expect(removeDotSegments('/a/bb/ccc/..g')).toEqual('/a/bb/ccc/..g');
+  });
+
+  it('should just append a g.. after a slash', () => {
+    expect(removeDotSegments('/a/bb/ccc/g..')).toEqual('/a/bb/ccc/g..');
+  });
+
+  it('should end with a slash if there is a trailing /.', () => {
+    expect(removeDotSegments('/a/bb/ccc/./g/.')).toEqual('/a/bb/ccc/g/');
+  });
+});

--- a/packages/resolve-url/resolve-url.js
+++ b/packages/resolve-url/resolve-url.js
@@ -1,5 +1,5 @@
-import isAbsoluteUrl from 'is-absolute-url';
-import { resolve } from 'relative-to-absolute-iri';
+import isAbsoluteUrl from './is-absolute-url';
+import { resolve } from './relative-to-absolute';
 
 const resolveUrl = ({ relative = '', base }) => {
   if (isAbsoluteUrl(relative)) {

--- a/plop-templates/library/package.json.hbs
+++ b/plop-templates/library/package.json.hbs
@@ -5,7 +5,7 @@
   "main": "{{kebabCase packageName}}.js",
   "keywords": [{{{packageKeywords}}}],
   "author": "{{userFullName}} <{{userEmail}}>",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Unfortunately, the two libs chosen for relative url resolution did not work in IE11 without compilation. 

- https://github.com/rubensworks/relative-to-absolute-iri.js
- https://github.com/sindresorhus/is-absolute-url

Each lib was embedded within `resolve-url`. Future versions of our toolkit should probably compile all of `node_modules` to prevent this from happening again.