### PR TITLE
fix(api-core): graceful exit when polling

### DIFF
--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -135,6 +135,8 @@ export default class AvApi {
   // condition for calls that should continue polling
   shouldPoll(response) {
     return (
+      response &&
+      response.config &&
       response.config.polling &&
       response.status === 202 &&
       response.config.attempt < response.config.pollingIntervals.length


### PR DESCRIPTION
Enables an AvApi.post call to exit gracefully if one of the subsequent polls is a 405 without a config