### PR TITLE
docs(analytics-core): clarify first arg to new AvSplunkAnalytics

### DIFF
--- a/packages/analytics-core/README.md
+++ b/packages/analytics-core/README.md
@@ -73,7 +73,7 @@ It defaults the url and level before sending.
 ```javascript
 import {AvSplunkAnalytics} from '@availity/analytics-core';
 
-const exmpleSplunkAnalytics = new AvSplunkAnalytics(AvLogMessages, isEnabled);
+const exampleSplunkAnalytics = new AvSplunkAnalytics(new AvLogMessages({ http, promise, merge }), isEnabled);
 ```
 
 ## Methods


### PR DESCRIPTION
Clarifies that to create a new `AvSplunkAnalytics`, you need to pass an instance of `AvLogMessages` rather than just the class