### PR TITLE
refactor(analytics-core): create copy of original payload to prevent …

### DIFF
--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -192,8 +192,12 @@ export default class AvAnalytics {
     properties.url = properties.url || window.location.href || 'N/A';
 
     this.plugins.forEach(plugin => {
+      const props = {
+        ...properties,
+      };
+
       if (isPluginEnabled(plugin) && typeof plugin.trackEvent === 'function') {
-        promises.push(plugin.trackEvent(properties));
+        promises.push(plugin.trackEvent(props));
       }
     });
     return this.Promise.all(promises);


### PR DESCRIPTION
If there is more than 1 plugin configured for the analytics core, we don't want to delete the original payload