### PR TITLE
refactor(analytics-core): removed default tpId to NA when not found

### DIFF
--- a/packages/analytics-core/src/dma.js
+++ b/packages/analytics-core/src/dma.js
@@ -32,8 +32,6 @@ export default class AvDmaAnalytics extends AvAnalyticsPlugin {
       properties.tradingPartnerId =
         properties.tradingPartnerId || properties.TradingPartnerId;
       delete properties.TradingPartnerId;
-    } else {
-      properties.tradingPartnerId = 'NA';
     }
 
     if (properties.customerId || properties.CustomerId) {

--- a/packages/analytics-core/src/tests/dma.test.js
+++ b/packages/analytics-core/src/tests/dma.test.js
@@ -26,9 +26,7 @@ describe('AvSplunkAnalytics', () => {
     const level = 'info';
     mockAvSplunkAnalytics.trackEvent({ level });
     expect(mockLog.send).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        { customerId: 'NA', tradingPartnerId: 'NA', data: { level } },
-      ])
+      expect.arrayContaining([{ customerId: 'NA', data: { level } }])
     );
   });
 });


### PR DESCRIPTION
This is being handled on the serverside now.