### PR TITLE
chore: add plop generator for api resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@
 -   [upload-core](packages/upload-core/README.md) - > Wrapper for tus-js-client
 -   [dl-core](packages/dl-core/README.md) - > Wrapper for js-file-download
 
+## Adding a new API Resource
+
+1. Run `npm run new`
+2. Select the "api resource" template
+3. Follow the prompts
+4. Export the resource in `api-core`, [here](packages/api-core/src/index.js)
+5. Export the resource in `api-axios`, [here](packages/api-axios/src/index.js)
+6. Export the resource in `api-angular`, [here](packages/api-angular/src/index.js)
+7. Add the resource to the README of `api-axios`, [here](packages/api-axios/README.md)
+8. Add the resource to the README of `api-angular`, [here](packages/api-angular/README.md)
+9. Add test that the resource is defined in `api-axios`, [here](packages/api-axios/src/tests/api.test.js)
+10. Add test that the resource is defined in `api-angular`, [here](packages/api-angular/src/tests/api.test.js)
+
 ## Contributing
 
 `skd-js` is a monorepo managed using [lerna](https://github.com/lerna/lerna) in independent mode (each packages is versioned and published individually).

--- a/plop-templates/resource/api-angular-resource.js.hbs
+++ b/plop-templates/resource/api-angular-resource.js.hbs
@@ -1,0 +1,12 @@
+import angular from 'angular';
+
+import { Av{{pascalCase resourceName}} } from '@availity/api-core';
+
+export default ($http, $q, avApiOptions) =>
+  new Av{{pascalCase resourceName}}({
+    http: $http,
+    promise: $q,
+    merge: angular.merge,
+    config: angular.copy(avApiOptions),
+  });
+

--- a/plop-templates/resource/api-axios-resource.js.hbs
+++ b/plop-templates/resource/api-axios-resource.js.hbs
@@ -1,0 +1,10 @@
+import axios from 'axios';
+import merge from 'merge-options-es5';
+import { Av{{pascalCase resourceName}} } from '@availity/api-core';
+
+export default new Av{{pascalCase resourceName}}({
+  http: axios,
+  promise: Promise,
+  merge,
+});
+

--- a/plop-templates/resource/api-core-ms-resource.js.hbs
+++ b/plop-templates/resource/api-core-ms-resource.js.hbs
@@ -1,0 +1,20 @@
+import AvMicroservice from '../ms';
+
+export default class Av{{pascalCase resourceName}} extends AvMicroservice {
+  constructor({ http, promise, merge, config }) {
+    const options = Object.assign(
+      {
+        path: '',
+        name: '',
+      },
+      config
+    );
+    super({
+      http,
+      promise,
+      merge,
+      config: options,
+    });
+  }
+}
+

--- a/plop-templates/resource/api-core-resource.js.hbs
+++ b/plop-templates/resource/api-core-resource.js.hbs
@@ -1,0 +1,19 @@
+import AvApi from '../api';
+
+export default class Av{{pascalCase resourceName}} extends AvApi {
+  constructor({ http, promise, merge, config }) {
+    const options = Object.assign(
+      {
+        path: '',
+        name: '',
+      },
+      config
+    );
+    super({
+      http,
+      promise,
+      merge,
+      config: options,
+    });
+  }
+}

--- a/plop-templates/resource/api-core-test.js.hbs
+++ b/plop-templates/resource/api-core-test.js.hbs
@@ -1,0 +1,28 @@
+import Av{{pascalCase resourceName}} from '../{{camelCase resourceName}}';
+
+const mockHttp = jest.fn(() => Promise.resolve({}));
+const mockMerge = jest.fn((...args) => Object.assign(...args));
+
+describe('Av{{pascalCase resourceName}}', () => {
+  let api;
+
+  test('should be defined', () => {
+    api = new Av{{pascalCase resourceName}}({
+      http: mockHttp,
+      promise: Promise,
+      merge: mockMerge,
+      config: {},
+    });
+    expect(api).toBeDefined();
+  });
+
+  test('should handle no config passed in', () => {
+    api = new Av{{pascalCase resourceName}}({
+      http: mockHttp,
+      promise: Promise,
+      merge: mockMerge,
+    });
+    expect(api).toBeDefined();
+  });
+});
+

--- a/plopfile.js
+++ b/plopfile.js
@@ -53,4 +53,57 @@ module.exports = plop => {
       },
     ],
   });
+
+  plop.setGenerator('api resource', {
+    description: 'Create new api resource',
+    prompts: [
+      {
+        type: 'input',
+        name: 'resourceName',
+        message: 'resource name',
+      },
+      {
+        type: 'confirm',
+        name: 'isMicroservice',
+        message: 'Is this resource for a microservice?',
+        default: false,
+      },
+    ],
+    actions: data => {
+      const actions = [
+        {
+          type: 'add',
+          path: 'packages/api-angular/src/{{camelCase resourceName}}.js',
+          templateFile: 'plop-templates/resource/api-angular-resource.js.hbs',
+        },
+        {
+          type: 'add',
+          path: 'packages/api-axios/src/{{camelCase resourceName}}.js',
+          templateFile: 'plop-templates/resource/api-axios-resource.js.hbs',
+        },
+        {
+          type: 'add',
+          path:
+            'packages/api-core/src/resources/tests/{{camelCase resourceName}}.test.js',
+          templateFile: 'plop-templates/resource/api-core-test.js.hbs',
+        },
+      ];
+
+      if (data.isMicroservice) {
+        actions.push({
+          type: 'add',
+          path: 'packages/api-core/src/resources/{{camelCase resourceName}}.js',
+          templateFile: 'plop-templates/resource/api-core-ms-resource.js.hbs',
+        });
+      } else {
+        actions.push({
+          type: 'add',
+          path: 'packages/api-core/src/resources/{{camelCase resourceName}}.js',
+          templateFile: 'plop-templates/resource/api-core-resource.js.hbs',
+        });
+      }
+
+      return actions;
+    },
+  });
 };


### PR DESCRIPTION
closes #114

Adds plop generator for adding a new api resource. Also adds a section to
the README that serves as a checklist for the developer creating the
resource and for the reviewer reviewing the PR.