### PR TITLE
Feature/upload scan timeout

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,1 @@
-extends: availity/browser
-env:
-  jest: true
+extends: availity

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-jest": "^24.1.0",
     "conventional-changelog-cli": "^2.0.11",
     "conventional-recommended-bump": "^5.0.0",
-    "eslint-config-availity": "^4.0.1",
+    "eslint-config-availity": "^4.0.8",
     "husky": "^2.1.0",
     "jest": "^24.1.0",
     "jest-environment-jsdom-global": "^1.1.0",

--- a/packages/.eslintrc.yaml
+++ b/packages/.eslintrc.yaml
@@ -1,0 +1,5 @@
+extends: availity/browser
+globals:
+    Buffer: false
+    global: false
+    process: false

--- a/packages/keyv-local-sync/src/index.js
+++ b/packages/keyv-local-sync/src/index.js
@@ -53,4 +53,4 @@ class KeyvLocalSync {
   }
 }
 
-module.exports = KeyvLocalSync;
+export default KeyvLocalSync;

--- a/packages/upload-core/src/upload.js
+++ b/packages/upload-core/src/upload.js
@@ -147,7 +147,7 @@ class Upload {
       this.onProgress.forEach(cb => cb());
       this.timeoutId = setTimeout(() => {
         this.scan();
-      }, 50);
+      }, 1000);
     };
 
     // eslint-disable-next-line unicorn/prefer-add-event-listener


### PR DESCRIPTION
- Increased upload timeout from 50ms to 1000ms. 
- Updates eslint-config-availity to 4.0.8
- style eslint fixes
- modified export of KeyvLocalSync from commonjs to module