### PR TITLE
feat(yup): added yup validation library methods

### DIFF
--- a/packages/yup/README.md
+++ b/packages/yup/README.md
@@ -1,0 +1,98 @@
+# yup
+> Method extensions for the [yup](https://github.com/jquense/yup)
+
+[![Version](https://img.shields.io/npm/v/@availity/yup.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/yup)
+
+## Install
+
+```bash
+npm install @availity/yup yup --save
+```
+
+## Usage
+
+Import the package in the root of your project somewhere and you will have access to all of the provided yup methods.
+
+```javascript
+import '@availity/yup'
+import * as yup from 'yup';
+
+const schema = yup.string().dateFormat('MM/DD/YYYY');
+
+schema.isValid('12-12-2012');
+```
+
+## Table of Contents
+
+- [isRequired](#isRequired)
+- [dateRange](#dateRange)
+- [dateFormat](#dateFormat)
+- [between](#between)
+
+> Note any date validation methods will required [moment](https://www.npmjs.com/package/moment) to be installed
+
+
+
+## Methods
+### isRequired [**String**,**Array**,**Number**]
+#### Parameters
+- **required** - `boolean`. **required**. Whether or not the given string is required.
+- **message** - `string`. Optional. Custom error message when invalid. Default: `This Field is Required.`
+
+#### Example
+```javascript
+yup.string().isRequired();
+yup.string().isRequired(true,"Custom Error Message");
+yup.number().isRequired();
+yup.array().isRequired();
+```
+
+### dateRange [**Object**]
+Evaluates a date range object.
+#### Parameters
+- **options** - `object`. **required**. Range Options.
+  - **min** - `string`. **required**. The min date that can be selected.
+  - **max** - `string`. **required**. The max date that can be selected.
+  - **format** - `string`. optional. The format to parse the dates with.
+- **message** - `string`. Optional. Custom error message when invalid. Default: "Date Range must be between XX/XX/XXXX and XX/XX/XXXX."
+
+
+#### Example
+```javascript
+yup.object().shape({
+    startDate: '',
+    endDate: ''
+}).dateRange({
+    min: '07/04/2012',
+    max: '07/12/2012'
+})
+```
+
+### between [**string**]
+Evaluates a single date sring.
+#### Parameters
+- **options** - `object`. **required**. Range Options.
+  - **min** - `string`. **required**. The min date that can be selected.
+  - **max** - `string`. **required**. The max date that can be selected.
+  - **format** - `string`. optional. The format to parse the dates with.
+- **message** - `string`. Optional. Custom error message when invalid. Default: "Date must be between XX/XX/XXXX and XX/XX/XXXX."
+
+#### Example
+```javascript
+yup.string().between({
+    min: '07/04/2012',
+    max: '07/12/2012'
+})
+```
+
+### dateFormat [**string**]
+Evaluates a single date sring.
+#### Parameters
+- **format** - `string`. optional. The format to parse the dates with. Default MM/DD/YYYY
+- **message** - `string`. Optional. Custom error message when invalid. Default: "Date must be between XX/XX/XXXX and XX/XX/XXXX."
+
+#### Example
+```javascript
+yup.string().format('MM-DD-YYYY');
+```
+

--- a/packages/yup/index.js
+++ b/packages/yup/index.js
@@ -1,0 +1,13 @@
+import * as yup from 'yup';
+import dateRange from './src/dateRange';
+import dateFormat from './src/dateFormat';
+import between from './src/between';
+import isRequired from './src/isRequired';
+
+yup.addMethod(yup.string, 'isRequired', isRequired);
+yup.addMethod(yup.number, 'isRequired', isRequired);
+yup.addMethod(yup.array, 'isRequired', isRequired);
+
+yup.addMethod(yup.object, 'dateRange', dateRange);
+yup.addMethod(yup.string, 'dateFormat', dateFormat);
+yup.addMethod(yup.string, 'between', between);

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@availity/yup",
+  "version": "1.0.0",
+  "description": "Additional Methods for Yup validation library",
+  "main": "index.js",
+  "typings":"typings/index.d.ts",
+  "scripts": {
+    "test": "test"
+  },
+  "keywords": [
+    "tus",
+    "resumable",
+    "upload",
+    "availity"
+  ],
+  "author": "Kyle Gray <kyle.gray@availity.com>",
+  "license": "MIT",
+  "peerDependencies": {
+    "yup": "^0.27.0",
+    "moment": "^2.24.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "yup": "^0.27.0",
+    "moment": "^2.24.0"
+  }
+}

--- a/packages/yup/src/between.js
+++ b/packages/yup/src/between.js
@@ -1,0 +1,36 @@
+import moment from 'moment';
+
+export default function({ min, max, format = 'MM/DD/YYYY' }, msg) {
+  const minDate = moment(
+    min,
+    ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+    true
+  );
+
+  const maxDate = moment(
+    max,
+    ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+    true
+  );
+
+  // Can't use arrow function because we rely on 'this' referencing yup's internals
+  return this.test({
+    name: 'between',
+    exclusive: true, // Validation errors don't stack
+    // NOTE: Intentional use of single quotes - yup will handle the string interpolation
+    message:
+      msg ||
+      `Date must be between ${minDate.format(format)} and ${maxDate.format(
+        format
+      )}`,
+    test(value) {
+      const date = moment(
+        value,
+        ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+        true
+      );
+
+      return date.isBetween(minDate, maxDate);
+    },
+  });
+}

--- a/packages/yup/src/dateFormat.js
+++ b/packages/yup/src/dateFormat.js
@@ -1,0 +1,19 @@
+import moment from 'moment';
+
+export default function(format = 'MM/DD/YYYY', msg) {
+  // Can't use arrow function because we rely on 'this' referencing yup's internals
+  return this.test({
+    name: 'format',
+    exclusive: true, // Validation errors don't stack
+    // NOTE: Intentional use of single quotes - yup will handle the string interpolation
+    message: msg || 'This field is invalid.',
+    test(value) {
+      const date = moment(
+        value,
+        ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+        true
+      );
+      return date.isValid();
+    },
+  });
+}

--- a/packages/yup/src/dateRange.js
+++ b/packages/yup/src/dateRange.js
@@ -1,0 +1,52 @@
+import moment from 'moment';
+
+export default function({ min, max, format = 'MM/DD/YYYY' }, msg) {
+  const minDate = moment(
+    min,
+    ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+    true
+  );
+
+  const maxDate = moment(
+    max,
+    ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+    true
+  );
+
+  // Can't use arrow function because we rely on 'this' referencing yup's internals
+  return this.test({
+    name: 'dateRange',
+    exclusive: true, // Validation errors don't stack
+    // NOTE: Intentional use of single quotes - yup will handle the string interpolation
+    message:
+      msg ||
+      `Date Range must be between ${minDate.format(
+        format
+      )} and ${maxDate.format(format)}`,
+    test(value) {
+      if (!value) return false;
+      let { startDate, endDate } = value;
+      if (!startDate || !endDate) return false;
+
+      startDate = moment(
+        startDate,
+        ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+        true
+      );
+
+      endDate = moment(
+        endDate,
+        ['MM/DD/YYYY', format, 'MMDDYYYY', 'YYYYMMDD'],
+        true
+      );
+
+      return (
+        startDate.isValid() &&
+        endDate.isValid() &&
+        endDate.isSameOrAfter(startDate) &&
+        startDate.isSameOrAfter(minDate) &&
+        endDate.isSameOrBefore(maxDate)
+      );
+    },
+  });
+}

--- a/packages/yup/src/isRequired.js
+++ b/packages/yup/src/isRequired.js
@@ -1,0 +1,22 @@
+function isRequired(isRequired = true, msg) {
+  return this.test({
+    name: 'isRequired',
+    exclusive: true,
+    message: msg || 'This field is required.',
+    test(value) {
+      if (isRequired) {
+        if (typeof value === 'number') {
+          return value !== undefined;
+        }
+        if (Array.isArray(value)) {
+          return value.length > 0;
+        }
+        // String ( If you want to check for null add nullable )
+        return value !== undefined && value !== '';
+      }
+      return true;
+    },
+  });
+}
+
+export default isRequired;

--- a/packages/yup/tests/between.test.js
+++ b/packages/yup/tests/between.test.js
@@ -1,0 +1,15 @@
+import * as yup from 'yup';
+import '..';
+
+describe('date', () => {
+  test('should validate', async () => {
+    const schema = yup.string().between({
+      min: '12/10/2012',
+      max: '12/13/2012',
+    });
+
+    const valid = await schema.isValid('12/11/2012');
+
+    expect(valid).toBe(true);
+  });
+});

--- a/packages/yup/tests/dateFormat.test.js
+++ b/packages/yup/tests/dateFormat.test.js
@@ -1,0 +1,34 @@
+import * as yup from 'yup';
+import '..';
+
+describe('date', () => {
+  test('should validate', async () => {
+    const schema = yup
+      .string()
+      .dateFormat()
+      .required();
+
+    const valid = await schema.isValid('12/12/2012');
+
+    expect(valid).toBe(true);
+  });
+
+  test('should return error if invalid', async () => {
+    const schema = yup
+      .string()
+      .dateFormat()
+      .required();
+
+    const valid = await schema.isValid('12/12/20122');
+
+    expect(valid).toBe(false);
+  });
+
+  test('should render custom error message', async () => {
+    const schema = yup.string().dateFormat('MM/DD/YYYY', 'Test Error Message');
+
+    await expect(schema.validate('12/02/20122')).rejects.toThrow(
+      'Test Error Message'
+    );
+  });
+});

--- a/packages/yup/tests/dateRange.test.js
+++ b/packages/yup/tests/dateRange.test.js
@@ -1,0 +1,43 @@
+import * as yup from 'yup';
+import '..';
+
+describe('date', () => {
+  test('should validate', async () => {
+    const schema = yup
+      .object()
+      .shape({
+        startDate: yup.string().isRequired(),
+        endDate: yup.string().isRequired(),
+      })
+      .dateRange({
+        min: '12/10/2012',
+        max: '12/13/2012',
+      });
+
+    const valid = await schema.isValid({
+      startDate: '12/11/2012',
+      endDate: '12/12/2012',
+    });
+
+    expect(valid).toBe(true);
+  });
+
+  test('should return error if invalid', async () => {
+    const schema = yup
+      .string()
+      .dateFormat()
+      .required();
+
+    const valid = await schema.isValid('12/12/20122');
+
+    expect(valid).toBe(false);
+  });
+
+  test('should render custom error message', async () => {
+    const schema = yup.string().dateFormat('MM/DD/YYYY', 'Test Error Message');
+
+    await expect(schema.validate('12/02/20122')).rejects.toThrow(
+      'Test Error Message'
+    );
+  });
+});

--- a/packages/yup/tests/isRequired.test.js
+++ b/packages/yup/tests/isRequired.test.js
@@ -1,0 +1,53 @@
+import * as yup from 'yup';
+import '..';
+
+describe('isRequired', () => {
+  test('should return error on empty input', async () => {
+    const schema = yup.string().isRequired();
+
+    const valid = await schema.isValid('');
+
+    expect(valid).toBe(false);
+  });
+
+  test('should return error on no number', async () => {
+    const schema = yup.number().isRequired();
+
+    const valid = await schema.isValid(null);
+
+    expect(valid).toBe(false);
+  });
+
+  test('should return error on empty array', async () => {
+    const schema = yup.array().isRequired();
+
+    const valid = await schema.isValid([]);
+
+    expect(valid).toBe(false);
+  });
+
+  test('should accept null input', async () => {
+    const schema = yup
+      .string()
+      .isRequired(true)
+      .nullable();
+
+    const valid = await schema.isValid(null);
+
+    expect(valid).toBe(true);
+  });
+
+  test('should accept input', async () => {
+    const schema = yup.string().isRequired(true);
+
+    const valid = await schema.isValid('Test');
+
+    expect(valid).toBe(true);
+  });
+
+  test('should render custom error message', async () => {
+    const schema = yup.string().isRequired(true, 'Test Error Message');
+
+    await expect(schema.validate()).rejects.toThrow('Test Error Message');
+  });
+});

--- a/packages/yup/typings/index.d.ts
+++ b/packages/yup/typings/index.d.ts
@@ -1,0 +1,28 @@
+import * as yup from 'yup';
+
+declare module 'yup' {
+  type DateRangeOptions = {
+    min: string;
+    max: string;
+    format?: string;
+  };
+
+  interface StringSchema<T extends string | null | undefined = string>
+    extends Schema<T> {
+    isRequired(required?: boolean, errorMessage?: string): StringSchema<T>;
+    dateFormat(format?: string, errorMessage?: string): StringSchema<T>;
+    between(options: DateRangeOptions, errorMessage?: string): StringSchema<T>;
+  }
+  interface ObjectSchema<T extends object | null | undefined = object>
+    extends Schema<T> {
+    dateRange(
+      options: DateRangeOptions,
+      errorMessage?: string
+    ): ObjectSchema<T>;
+  }
+
+  interface ArraySchema<T> extends BasicArraySchema<T[]>{
+    isRequired(required?: boolean, errorMessage?: string): ArraySchema<T>;
+  }
+
+}


### PR DESCRIPTION
Instead of creating our own `yup` package that we can import and use we can just create `methods` that add on functionality to the existing `yup` library and import just like a style sheet at the entry point of our projects.

```javascript
import '@availity/yup';

import * as yup from 'yup'

// use our custom methods
yup.string().dateFormat().isRequired()
```