### PR TITLE
fix(api-core): do not use config url when resolving location header

### DIFF
--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -119,7 +119,7 @@ export default class AvApi {
   getLocation(response) {
     let locationUrl;
     const { config, headers = {} } = response;
-    const { getHeader, base, url } = config;
+    const { getHeader, base } = config;
     const { location, Location } = headers;
 
     if (getHeader) {
@@ -128,7 +128,7 @@ export default class AvApi {
       locationUrl = location || Location;
     }
 
-    return resolveUrl({ relative: locationUrl, base: base || url });
+    return resolveUrl({ relative: locationUrl, base });
   }
 
   // condition for calls that should continue polling

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -590,7 +590,7 @@ describe('AvApi', () => {
           Location: testLocation,
         },
       };
-      expect(api.getLocation(testResponse)).toBe('https://api.local/test');
+      expect(api.getLocation(testResponse)).toBe('https://dev.local/test');
     });
   });
 


### PR DESCRIPTION
Removing response url from relative url calculation.