### PR TITLE
perf(api-core): use userId from params if it exists in getOrganizations

### DIFF
--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -23,9 +23,14 @@ export default class AvOrganizations extends AvApi {
   }
 
   getOrganizations(config) {
+    if (config && config.params && config.params.userId) {
+      return this.query(config);
+    }
+
     if (!this.avUsers || !this.avUsers.me) {
       throw new Error('avUsers must be defined');
     }
+
     return this.avUsers
       .me()
       .then(user => this.queryOrganizations(user, config));

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -13,6 +13,10 @@ const mockAvUsers = {
 describe('AvOrganizations', () => {
   let api;
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('should be defined', () => {
     api = new AvOrganizations({
       http: mockHttp,
@@ -102,5 +106,25 @@ describe('AvOrganizations', () => {
       mockUser,
       testConfig
     );
+  });
+
+  test('getOrganizations() should skip call to avUsers.me() when userId provided and then query()', async () => {
+    api = new AvOrganizations({
+      http: mockHttp,
+      promise: Promise,
+      merge: mockMerge,
+      avUsers: mockAvUsers,
+      config: {},
+    });
+    api.queryOrganizations = jest.fn();
+    api.query = jest.fn();
+
+    const testConfig = { name: 'testName', params: { userId: 'bmoolenaar' } };
+
+    await api.getOrganizations(testConfig);
+
+    expect(api.queryOrganizations).not.toHaveBeenCalled();
+    expect(api.avUsers.me).not.toHaveBeenCalled();
+    expect(api.query).toHaveBeenLastCalledWith(testConfig);
   });
 });


### PR DESCRIPTION
Skips unnecessary call to `avUsers` resource if the `userId` for the call
is already defined in the `params`

closes #147 
