### PR TITLE
perf(api-core): use userId if it exists in get,set application settings

### DIFF
--- a/packages/api-core/src/resources/settings.js
+++ b/packages/api-core/src/resources/settings.js
@@ -25,6 +25,12 @@ export default class AvSettings extends AvApi {
     if (!this.avUsers || !this.avUsers.me) {
       throw new Error('avUsers must be defined');
     }
+
+    if (config && config.params && config.params.userId) {
+      const queryConfig = this.addParams({ applicationId }, config);
+      return this.query(queryConfig);
+    }
+
     return this.avUsers.me().then(user => {
       const queryConfig = this.addParams(
         { applicationId, userId: user.id },
@@ -50,6 +56,11 @@ export default class AvSettings extends AvApi {
 
     if (!applicationId && (!data || !data.scope || !data.scope.applicationId)) {
       throw new Error('applicationId must be defined');
+    }
+
+    if (data && data.scope && data.scope.userId) {
+      data.scope.applicationId = applicationId;
+      return this.update(data, config);
     }
 
     return this.avUsers.me().then(user => {

--- a/packages/api-core/src/resources/tests/settings.test.js
+++ b/packages/api-core/src/resources/tests/settings.test.js
@@ -15,6 +15,10 @@ const mockAvUsers = {
 describe('AvSettings', () => {
   let api;
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   beforeEach(() => {
     api = new AvSettings({
       http: mockHttp,
@@ -56,6 +60,19 @@ describe('AvSettings', () => {
       expect(() => api.getApplication('appId')).toThrow(
         'avUsers must be defined'
       );
+    });
+
+    test('should skip call to avUsers.me if userId is in config params', async () => {
+      const expectedQuery = {
+        params: {
+          applicationId: testAppId,
+          userId: 'bmoolenaar',
+        },
+      };
+      const testConfig = { params: { userId: 'bmoolenaar' } };
+      await api.getApplication(testAppId, testConfig);
+      expect(mockAvUsers.me).not.toHaveBeenCalled();
+      expect(api.query).toHaveBeenCalledWith(expectedQuery);
     });
   });
 
@@ -101,6 +118,22 @@ describe('AvSettings', () => {
       expect(() => api.setApplication('appId', {})).toThrow(
         'avUsers must be defined'
       );
+    });
+
+    test('should skip call to avUsers.me if userId is in data.scope', async () => {
+      const testData = { scope: { userId: 'bmoolenaar' }, key: 'value' };
+      const testConfig = {};
+      const expectedUpdate = {
+        scope: {
+          applicationId: testAppId,
+          userId: 'bmoolenaar',
+        },
+        key: 'value',
+      };
+
+      await api.setApplication(testAppId, testData, testConfig);
+      expect(mockAvUsers.me).not.toHaveBeenCalled();
+      expect(api.update).toHaveBeenCalledWith(expectedUpdate, testConfig);
     });
   });
 });


### PR DESCRIPTION
Skips unnecessary call to `avUsers` resource if the `userId` for the call
is already defined in `config.params` (for `getApplication`) or `data.scope` (for `setApplication`)