### PR TITLE
Fix/undefined error

### DIFF
--- a/packages/api-core/src/flattenObject.js
+++ b/packages/api-core/src/flattenObject.js
@@ -9,10 +9,10 @@ const flattenObject = ob =>
       Object.keys(flatObject).forEach(k2 => {
         toReturn[
           `${k}${isArray ? k2.replace(/^(\d+)(\..*)?/, '[$1]$2') : `.${k2}`}`
-        ] = flatObject[k2].toString();
+        ] = flatObject[k2] && flatObject[k2].toString();
       });
     } else {
-      toReturn[k] = ob[k].toString();
+      toReturn[k] = ob[k] && ob[k].toString();
     }
 
     return toReturn;

--- a/packages/api-core/src/flattenObject.js
+++ b/packages/api-core/src/flattenObject.js
@@ -1,4 +1,8 @@
 // Copied from https://github.com/Availity/sdk-js/blob/master/packages/native-form/flattenObject.js
+const parseValue = value => {
+  return value === undefined || value === null ? value : value.toString();
+};
+
 const flattenObject = ob =>
   Object.keys(ob).reduce((toReturn, k) => {
     if (Object.prototype.toString.call(ob[k]) === '[object Date]') {
@@ -6,13 +10,14 @@ const flattenObject = ob =>
     } else if (ob[k] && typeof ob[k] === 'object') {
       const flatObject = flattenObject(ob[k]);
       const isArray = Array.isArray(ob[k]);
+
       Object.keys(flatObject).forEach(k2 => {
         toReturn[
           `${k}${isArray ? k2.replace(/^(\d+)(\..*)?/, '[$1]$2') : `.${k2}`}`
-        ] = flatObject[k2] && flatObject[k2].toString();
+        ] = parseValue(flatObject[k2]);
       });
     } else {
-      toReturn[k] = ob[k] && ob[k].toString();
+      toReturn[k] = parseValue(ob[k]);
     }
 
     return toReturn;

--- a/packages/api-core/src/tests/flattenObject.test.js
+++ b/packages/api-core/src/tests/flattenObject.test.js
@@ -1,6 +1,6 @@
 import flattenObject from '../flattenObject';
 
-describe('AvApi', () => {
+describe('flattenObject', () => {
   test('should flatten', () => {
     const obj = {
       int: 123,

--- a/packages/api-core/src/tests/flattenObject.test.js
+++ b/packages/api-core/src/tests/flattenObject.test.js
@@ -1,0 +1,32 @@
+import flattenObject from '../flattenObject';
+
+describe('AvApi', () => {
+  test('should flatten', () => {
+    const obj = {
+      int: 123,
+      obj: {
+        string: 'string',
+      },
+    };
+
+    const flatObj = flattenObject(obj);
+    expect(flatObj.int).toBe('123');
+    expect(flatObj['obj.string']).toBe('string');
+  });
+
+  test('handles undefined', () => {
+    const obj = {
+      int: 123,
+      string: undefined,
+      obj: {
+        int: 123,
+        string: 'string',
+      },
+    };
+
+    const flatObj = flattenObject(obj);
+    expect(flatObj.int).toBe('123');
+    expect(flatObj['obj.string']).toBe('string');
+    expect(flatObj.string).toBeUndefined();
+  });
+});

--- a/packages/api-core/src/tests/flattenObject.test.js
+++ b/packages/api-core/src/tests/flattenObject.test.js
@@ -16,8 +16,9 @@ describe('AvApi', () => {
 
   test('handles undefined', () => {
     const obj = {
-      int: 123,
-      string: undefined,
+      int: 0,
+      false: false,
+      undefined,
       obj: {
         int: 123,
         string: 'string',
@@ -25,8 +26,9 @@ describe('AvApi', () => {
     };
 
     const flatObj = flattenObject(obj);
-    expect(flatObj.int).toBe('123');
+    expect(flatObj.int).toBe('0');
+    expect(flatObj.false).toBe('false');
     expect(flatObj['obj.string']).toBe('string');
-    expect(flatObj.string).toBeUndefined();
+    expect(flatObj.undefined).toBeUndefined();
   });
 });

--- a/packages/native-form/src/flattenObject.js
+++ b/packages/native-form/src/flattenObject.js
@@ -8,10 +8,10 @@ const flattenObject = ob =>
       Object.keys(flatObject).forEach(k2 => {
         toReturn[
           `${k}${isArray ? k2.replace(/^(\d+)(\..*)?/, '[$1]$2') : `.${k2}`}`
-        ] = flatObject[k2].toString();
+        ] = flatObject[k2] && flatObject[k2].toString();
       });
     } else {
-      toReturn[k] = ob[k].toString();
+      toReturn[k] = ob[k] && ob[k].toString();
     }
 
     return toReturn;

--- a/packages/native-form/src/flattenObject.js
+++ b/packages/native-form/src/flattenObject.js
@@ -1,3 +1,8 @@
+// Copied from https://github.com/Availity/sdk-js/blob/master/packages/native-form/flattenObject.js
+const parseValue = value => {
+  return value === undefined || value === null ? value : value.toString();
+};
+
 const flattenObject = ob =>
   Object.keys(ob).reduce((toReturn, k) => {
     if (Object.prototype.toString.call(ob[k]) === '[object Date]') {
@@ -5,13 +10,14 @@ const flattenObject = ob =>
     } else if (ob[k] && typeof ob[k] === 'object') {
       const flatObject = flattenObject(ob[k]);
       const isArray = Array.isArray(ob[k]);
+
       Object.keys(flatObject).forEach(k2 => {
         toReturn[
           `${k}${isArray ? k2.replace(/^(\d+)(\..*)?/, '[$1]$2') : `.${k2}`}`
-        ] = flatObject[k2] && flatObject[k2].toString();
+        ] = parseValue(flatObject[k2]);
       });
     } else {
-      toReturn[k] = ob[k] && ob[k].toString();
+      toReturn[k] = parseValue(ob[k]);
     }
 
     return toReturn;

--- a/packages/native-form/tests/flattenObject.test.js
+++ b/packages/native-form/tests/flattenObject.test.js
@@ -1,6 +1,6 @@
 import flattenObject from '../src/flattenObject';
 
-describe('AvApi', () => {
+describe('flattenObject', () => {
   test('should flatten', () => {
     const obj = {
       int: 123,

--- a/packages/native-form/tests/flattenObject.test.js
+++ b/packages/native-form/tests/flattenObject.test.js
@@ -16,8 +16,9 @@ describe('AvApi', () => {
 
   test('handles undefined', () => {
     const obj = {
-      int: 123,
-      string: undefined,
+      int: 0,
+      false: false,
+      undefined,
       obj: {
         int: 123,
         string: 'string',
@@ -25,8 +26,9 @@ describe('AvApi', () => {
     };
 
     const flatObj = flattenObject(obj);
-    expect(flatObj.int).toBe('123');
+    expect(flatObj.int).toBe('0');
+    expect(flatObj.false).toBe('false');
     expect(flatObj['obj.string']).toBe('string');
-    expect(flatObj.string).toBeUndefined();
+    expect(flatObj.undefined).toBeUndefined();
   });
 });

--- a/packages/native-form/tests/flattenObject.test.js
+++ b/packages/native-form/tests/flattenObject.test.js
@@ -1,0 +1,32 @@
+import flattenObject from '../src/flattenObject';
+
+describe('AvApi', () => {
+  test('should flatten', () => {
+    const obj = {
+      int: 123,
+      obj: {
+        string: 'string',
+      },
+    };
+
+    const flatObj = flattenObject(obj);
+    expect(flatObj.int).toBe('123');
+    expect(flatObj['obj.string']).toBe('string');
+  });
+
+  test('handles undefined', () => {
+    const obj = {
+      int: 123,
+      string: undefined,
+      obj: {
+        int: 123,
+        string: 'string',
+      },
+    };
+
+    const flatObj = flattenObject(obj);
+    expect(flatObj.int).toBe('123');
+    expect(flatObj['obj.string']).toBe('string');
+    expect(flatObj.string).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This function would crash when trying to call `toString` on an `undefined` or `null` variable. If the value is `undefined` or `null` then that value will be returned, otherwise `toString` will be called.

Closes #179
