### PR TITLE
fix(api-core): Corrected PDF expected response

### DIFF
--- a/packages/api-core/src/resources/pdfs.js
+++ b/packages/api-core/src/resources/pdfs.js
@@ -16,7 +16,7 @@ export default class AvPdfs extends AvApi {
   }
 
   onPdf(response) {
-    window.location = response.data.pdf.href;
+    window.location = response.data.links.pdf.href;
   }
 
   getPdf(data, config) {

--- a/packages/api-core/src/resources/tests/pdfs.test.js
+++ b/packages/api-core/src/resources/tests/pdfs.test.js
@@ -39,8 +39,10 @@ describe('AvPdfs', () => {
 
     const response = {
       data: {
-        pdf: {
-          href: '/path/to/sample.pdf',
+        links: {
+          pdf: {
+            href: '/path/to/sample.pdf',
+          },
         },
       },
     };


### PR DESCRIPTION
`utils/v1/pdfs` (success) response format is:

```json
{
  "links" : {
    "pdf" : {
      "href" : "host/api/utils/v1/pdfs/{id}.pdf"
    },
    "self" : {
      "href" : "hostapi/utils/v1/pdfs/{id}"
    }
  },
  "id" : "4221042154297172908",
  "createdDate" : "{timestamp}",
  "updatedDate" : "{timestamp}",
  "expirationDate" : "{timestamp}",
  "status" : "Complete",
  "statusCode" : "4",
  "applicationId" : "{requestedAppID}",
  "fileName" : "{requestedFileName}"
}
```