### PR TITLE
feat(relay-id): new small helper package to help deal with relay ids

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -45,6 +45,7 @@ module.exports = {
             'features/env-var',
             'features/messaging',
             'features/native-form',
+            'features/relay-id',
             'features/resolve-url',
             'features/yup',
             'features/exceptions',

--- a/docs/source/features/relay-id.md
+++ b/docs/source/features/relay-id.md
@@ -1,0 +1,32 @@
+---
+title: relay-id
+summary: Small package containing helpers for encoding/decoding ids according to the relay specification
+---
+
+[![Version](https://img.shields.io/npm/v/@availity/relay-id.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/relay-id)
+
+## Install
+
+### NPM
+
+```bash
+$ npm install @availity/relay-id
+```
+
+### Yarn
+
+```bash
+$ yarn add @availity/relay-id
+```
+
+## Usage
+
+```js
+import { fromGlobalId, toGlobalId } from '@availity/relay-id';
+
+// Will return {type: 'User', id: '789'}
+const { type, id } = fromGlobalId('VXNlcjo3ODk=');
+
+// Will return global id of VXNlcjo3ODk=
+const globalId = toGlobalId('User', '789');
+```

--- a/packages/relay-id/README.md
+++ b/packages/relay-id/README.md
@@ -1,0 +1,21 @@
+# relay-id
+
+> Small package containing helpers for encoding/decoding ids according to the relay specification
+
+[![Version](https://img.shields.io/npm/v/@availity/relay-id.svg?style=for-the-badge)](https://www.npmjs.com/package/@availity/relay-id)
+
+## Install
+
+### NPM
+
+```bash
+$ npm install @availity/relay-id
+```
+
+### Yarn
+
+```bash
+$ yarn add @availity/relay-id
+```
+
+## [Documentation](https://availity.github.io/sdk-js/features/relay-id)

--- a/packages/relay-id/index.d.ts
+++ b/packages/relay-id/index.d.ts
@@ -7,3 +7,5 @@ declare function base64(decodedString: string): string;
 declare function unbase64(encodedString: string): string;
 declare function toGlobalId(type: string, id: string): string;
 declare function fromGlobalId(globalId: string): ResolvedGlobalId;
+
+export { base64, unbase64, toGlobalId, fromGlobalId };

--- a/packages/relay-id/index.d.ts
+++ b/packages/relay-id/index.d.ts
@@ -1,0 +1,9 @@
+export type ResolvedGlobalId = {
+  type: string;
+  id: string;
+};
+
+declare function base64(decodedString: string): string;
+declare function unbase64(encodedString: string): string;
+declare function toGlobalId(type: string, id: string): string;
+declare function fromGlobalId(globalId: string): ResolvedGlobalId;

--- a/packages/relay-id/package.json
+++ b/packages/relay-id/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@availity/relay-id",
+  "version": "1.0.0",
+  "description": "Simple package to decode/encode relay ids for graphql microservices that leverage the relay spec.",
+  "main": "lib/index.js",
+  "module": "src/index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "test"
+  },
+  "keywords": [
+    "availity",
+    "form",
+    "native",
+    "submission"
+  ],
+  "author": "Kyle Gray <kyle.gray@availity.com>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/relay-id/src/index.js
+++ b/packages/relay-id/src/index.js
@@ -1,0 +1,32 @@
+/**
+ * Inspired By https://github.com/graphql-compose/graphql-compose-relay/blob/master/src/globalId.js
+ */
+
+export function base64(i) {
+  return btoa(i);
+}
+
+export function unbase64(i) {
+  return atob(i);
+}
+
+/**
+ * Takes a type name and an ID specific to that type name, and returns a
+ * "global ID" that is unique among all types.
+ */
+export function toGlobalId(type, id) {
+  return base64([type, id].join(':'));
+}
+
+/**
+ * Takes the "global ID" created by toGlobalID, and returns the type name and ID
+ * used to create it.
+ */
+export function fromGlobalId(globalId) {
+  const unbasedGlobalId = unbase64(globalId);
+  const delimiterPos = unbasedGlobalId.indexOf(':');
+  return {
+    type: unbasedGlobalId.substring(0, delimiterPos),
+    id: unbasedGlobalId.substring(delimiterPos + 1),
+  };
+}

--- a/packages/relay-id/tests/test.js
+++ b/packages/relay-id/tests/test.js
@@ -1,0 +1,31 @@
+import { base64, unbase64, toGlobalId, fromGlobalId } from '../src';
+
+describe('globalId', () => {
+  it('should have correct method base64()', () => {
+    expect(base64('123')).toBe('MTIz');
+    expect(base64('lksdnfkksdknsdc:123')).toBe('bGtzZG5ma2tzZGtuc2RjOjEyMw==');
+  });
+
+  it('should have correct method unbase64()', () => {
+    expect(unbase64('MTIz')).toBe('123');
+    expect(unbase64('bGtzZG5ma2tzZGtuc2RjOjEyMw==')).toBe(
+      'lksdnfkksdknsdc:123'
+    );
+  });
+
+  it('should have correct method toGlobalId()', () => {
+    expect(toGlobalId('User', '789')).toBe('VXNlcjo3ODk=');
+    expect(toGlobalId('Article', 22)).toBe('QXJ0aWNsZToyMg==');
+  });
+
+  it('should have correct method fromGlobalId()', () => {
+    expect(fromGlobalId('VXNlcjo3ODk=')).toEqual({
+      type: 'User',
+      id: '789',
+    });
+    expect(fromGlobalId('QXJ0aWNsZToyMg==')).toEqual({
+      type: 'Article',
+      id: '22',
+    });
+  });
+});


### PR DESCRIPTION
Title says it all.

Its a subset of `graphql-relay` or `graphql-compose-relay`. Just contains the logic for encoding/decoding.

Example:
```js
import { fromGlobalId, toGlobalId } from '@availity/relay-id';

// Will return {type: 'User', id: '789'}
const { type, id } = fromGlobalId('VXNlcjo3ODk=');

// Will return global id of VXNlcjo3ODk=
const globalId = toGlobalId('User', '789');
```

[Inspired By](https://github.com/graphql-compose/graphql-compose-relay/blob/master/src/globalId.js)