### PR TITLE
feat(upload-core): increase file upload polling time and add config

### DIFF
--- a/docs/source/api/uploads.md
+++ b/docs/source/api/uploads.md
@@ -33,6 +33,7 @@ $ yarn add @availity/upload-core tus-js-client
 -   maxSize: maximum size allowed per file
 -   metadata: object mapping metadata keys and values to add to the TUS upload
 -   allowedFileNameCharacters: restrict the file name characters to a regex set
+-   pollingTime: custom av scan polling time (default 5000ms)
 
 ```js
 import Upload from '@availity/upload-core';
@@ -45,6 +46,7 @@ const upload = new Upload(file, {
     maxSize: 3e8,
     metadata: { key: 'value' },
     allowedFileNameCharacters: '_a-zA-Z0-9 ', // alphanumeric, spaces, underscore
+    pollingTime: 1000,
 });
 upload.start();
 ```

--- a/packages/upload-core/src/upload.js
+++ b/packages/upload-core/src/upload.js
@@ -18,6 +18,7 @@ const defaultOptions = {
   endpoint: '/ms/api/availity/internal/core/vault/upload/v1/resumable',
   chunkSize: 3e6, // 3MB
   removeFingerprintOnSuccess: true,
+  pollingTime: 5000,
   retryDelays: [0, 1000, 3000, 5000],
   stripFileNamePathSegments: true,
   fingerprint(file, options = {}, callback) {
@@ -215,7 +216,7 @@ class Upload {
       this.onProgress.forEach(cb => cb());
       this.timeoutId = setTimeout(() => {
         this.scan();
-      }, this.options.pollingTime || 5000);
+      }, this.options.pollingTime);
     };
 
     // eslint-disable-next-line unicorn/prefer-add-event-listener

--- a/packages/upload-core/src/upload.js
+++ b/packages/upload-core/src/upload.js
@@ -215,7 +215,7 @@ class Upload {
       this.onProgress.forEach(cb => cb());
       this.timeoutId = setTimeout(() => {
         this.scan();
-      }, 1000);
+      }, this.options.pollingTime || 5000);
     };
 
     // eslint-disable-next-line unicorn/prefer-add-event-listener


### PR DESCRIPTION
Update to increase av scan upload polling time to 5000ms by default, but allow for customization. 

closes #198 
