### PR TITLE
perf(api-core): use userId if it exists in call to getRegions

### DIFF
--- a/packages/api-core/src/resources/regions.js
+++ b/packages/api-core/src/resources/regions.js
@@ -24,9 +24,14 @@ export default class AvRegions extends AvApi {
   }
 
   getRegions(config) {
+    if (config && config.params && config.params.userId) {
+      return this.query(config);
+    }
+
     if (!this.avUsers || !this.avUsers.me) {
       throw new Error('avUsers must be defined');
     }
+
     return this.avUsers.me().then(user => {
       const queryConfig = this.addParams({ userId: user.id }, config);
       return this.query(queryConfig);

--- a/packages/api-core/src/resources/tests/regions.test.js
+++ b/packages/api-core/src/resources/tests/regions.test.js
@@ -13,6 +13,10 @@ const mockAvUsers = {
 describe('AvRegions', () => {
   let api;
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('should be defined', () => {
     api = new AvRegions({
       http: mockHttp,
@@ -86,6 +90,26 @@ describe('AvRegions', () => {
     Object.assign(expectedConfig.params, { userId: mockUser.id });
     await api.getRegions(testConfig);
     expect(api.query).toHaveBeenLastCalledWith(expectedConfig);
+  });
+
+  test('getRegions should skip call to avUsers.me() if a userId is provided', async () => {
+    api = new AvRegions({
+      http: mockHttp,
+      promise: Promise,
+      merge: mockMerge,
+      avUsers: mockAvUsers,
+      config: {},
+    });
+    api.query = jest.fn();
+
+    const testConfig = {
+      name: 'testName',
+      params: { userId: mockUser.id },
+    };
+
+    await api.getRegions(testConfig);
+    expect(api.query).toHaveBeenLastCalledWith(testConfig);
+    expect(api.avUsers.me).not.toHaveBeenCalled();
   });
 
   test('getRegions should handle undefined config param', async () => {


### PR DESCRIPTION
Avoids unnecessary call to `avUsers.me()` if we already have a `userId`.