### PR TITLE
refactor(api-core): updated send beacon to send as encoded form data

### DIFF
--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -212,7 +212,12 @@ export default class AvApi {
     }
 
     if (navigator.sendBeacon) {
-      const result = navigator.sendBeacon(config.url, config.data);
+      const result = navigator.sendBeacon(
+        config.url,
+        new Blob([config.data], {
+          type: 'application/x-www-form-urlencoded',
+        })
+      );
       // A truthy return value from navigator.sendBeacon means the browser successfully queued the request
       if (result) return this.Promise.resolve();
     }

--- a/packages/api-core/src/resources/logs.js
+++ b/packages/api-core/src/resources/logs.js
@@ -19,10 +19,7 @@ export default class AvLogMessages extends AvApi {
     delete entries.level;
     const payload = { level, entries };
     const flattened = flattenObject(payload);
-    return Object.keys(flattened).reduce((accum, key) => {
-      accum.append(key, flattened[key]);
-      return accum;
-    }, new FormData());
+    return new URLSearchParams(flattened);
   }
 
   debug(entries) {

--- a/packages/api-core/src/resources/tests/logs.test.js
+++ b/packages/api-core/src/resources/tests/logs.test.js
@@ -30,7 +30,7 @@ describe('AvLogMessages', () => {
     const entries = { foo: 'bar', deeply: { nested: 'value' } };
     const sent = api.send(level, entries);
 
-    expect(sent instanceof FormData).toBe(true);
+    expect(sent instanceof URLSearchParams).toBe(true);
     expect(sent.get('level')).toBe('testLevel');
     expect(sent.get('entries.foo')).toBe('bar');
     expect(sent.get('entries.deeply.nested')).toBe('value');

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -1122,7 +1122,7 @@ describe('AvApi', () => {
       const config = {
         testValue: 'test',
       };
-      const data = new FormData();
+      const data = new URLSearchParams();
       data.append('testData', 'data');
 
       const expectedConfig = {
@@ -1139,7 +1139,9 @@ describe('AvApi', () => {
       expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
       expect(navigator.sendBeacon).toHaveBeenLastCalledWith(
         expectedConfig.url,
-        expectedConfig.data
+        new Blob([expectedConfig.data], {
+          type: 'application/x-www-form-urlencoded',
+        })
       );
       // Check that sendBeacon resolves with empty object
       expect(resp).toBeUndefined();
@@ -1169,7 +1171,9 @@ describe('AvApi', () => {
       expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
       expect(navigator.sendBeacon).toHaveBeenLastCalledWith(
         expectedConfig.url,
-        expectedConfig.data
+        new Blob([expectedConfig.data], {
+          type: 'application/x-www-form-urlencoded',
+        })
       );
       // Check api.request was called
       expect(api.request).toHaveBeenLastCalledWith(expectedConfig, undefined);


### PR DESCRIPTION
Modifies the `content-type` from `multipart/form-data` to `url-encoded` so that it plays nicely with our A1 and A2 APIs.