### PR TITLE
docs(api-core): Updated docs to reflect new patch method

### DIFF
--- a/docs/source/api/getting-started.md
+++ b/docs/source/api/getting-started.md
@@ -159,6 +159,16 @@ put(id, data, config);
 put(data, config);
 ```
 
+#### patch
+
+Update an entity with a PATCH call. When an id is passed in, `/id` is added to the url.
+
+```js
+patch(id, data, config);
+// or wihthout id
+patch(data, config);
+```
+
 #### remove or delete
 
 Remove an entity with a DELETE call. When an id is passed in, `/id` is added to the url. If the first parameter is a string or number, it is treated as an ID, otherwise data.

--- a/docs/source/api/getting-started.md
+++ b/docs/source/api/getting-started.md
@@ -151,7 +151,7 @@ Update an entity with a PUT call. When an id is passed in, `/id` is added to the
 
 ```js
 update(id, data, config);
-// or wihthout id
+// or without id
 update(data, config);
 // or
 put(id, data, config);
@@ -165,7 +165,7 @@ Update an entity with a PATCH call. When an id is passed in, `/id` is added to t
 
 ```js
 patch(id, data, config);
-// or wihthout id
+// or without id
 patch(data, config);
 ```
 


### PR DESCRIPTION
Forgot to update docs when working on patch(). This PR updates docs for api-core to include the new method.