### PR TITLE
Fix/yup date

### DIFF
--- a/docs/source/features/yup.md
+++ b/docs/source/features/yup.md
@@ -32,15 +32,23 @@ const schema = yup.string().isRequired(true, 'This field is required.');
 schema.isValid('12-12-2012');
 ```
 
-If you want to utilize the custom date validators you can import using `/moment` instead of the default like:
+If you want to utilize the custom date validators you need to import them directly:
 
 ```js
-import '@availity/yup/moment';
-import * as yup from 'yup';
+import { avDate, dateRange } from '@availity/yup';
 
-const schema = yup.avDate();
+const dateSchema = avDate();
+const dateRangeSchema = dateRange({
+      startKey: 'helloDate',
+      endKey: 'worldDate',
+}).between('12/10/2012', '12/13/2012');
 
-schema.isValid('12-12-2012');
+
+dateSchema.isValid('12-12-2012');
+dateRangeSchema.isValid({
+    helloDate: '12/11/2012',
+    worldDate: '12/12/2012',
+});
 ```
 
 ## Table of Contents
@@ -140,17 +148,16 @@ Evaluates a date range object.
 ### Example
 
 ```js
-import '@availity/yup';
-import * as yup from 'yup';
+import { dateRange } from '@availity/yup';
 
-const schema = yup.dateRange({
-    min: '07/04/2012',
-    max: '07/12/2012',
-});
+const dateRangeSchema = dateRange({
+    startKey: 'helloDate',
+    endKey: 'worldDate',
+}).between('12/10/2012', '12/13/2012');
 
-schema.isValid({
-    startDate: '07/05/2012',
-    endDate: '07/10/2012',
+dateRangeSchema.isValid({
+    helloDate: '12/11/2012',
+    worldDate: '12/12/2012',
 });
 ```
 
@@ -169,10 +176,9 @@ Accepts range of dates the date range can fall between.
 #### example
 
 ```js
-import '@availity/yup';
-import * as yup from 'yup';
+import { dateRange } from '@availity/yup';
 
-const schema = yup.dateRange().between('12/01/2012', '12/10/2012');
+const schema = dateRange().between('12/01/2012', '12/10/2012');
 
 schema.isValid({
     startDate: '12/02/2012',
@@ -192,10 +198,9 @@ Accepts date the date range must start after.
 #### example
 
 ```js
-import '@availity/yup';
-import * as yup from 'yup';
+import { dateRange } from '@availity/yup';
 
-const schema = yup.dateRange().min('12/01/2012');
+const schema = dateRange().min('12/01/2012');
 
 schema.isValid({
     startDate: '12/02/2012',
@@ -215,10 +220,9 @@ Accepts date, the date range must start before.
 #### example
 
 ```js
-import '@availity/yup';
-import * as yup from 'yup';
+import { dateRange } from '@availity/yup';
 
-const schema = yup.dateRange().max('12/10/2012');
+const schema = dateRange().max('12/10/2012');
 
 schema.isValid({
     startDate: '12/02/2012',
@@ -244,10 +248,9 @@ Evaluates if date range is within a set distance
 #### example
 
 ```js
-import '@availity/yup';
-import * as yup from 'yup';
+import { dateRange } from '@availity/yup';
 
-const schema = yup.dateRange().distance({
+const schema = dateRange().distance({
     min: {
         value: 3,
         units: 'day',
@@ -279,10 +282,9 @@ Takes an object of dates the given date must fall between
 #### example
 
 ```js
-import '@availity/yup';
-import * as yup from 'yup';
+import { avDate } from '@availity/yup';
 
-const schema = yup.avDate().between('12/01/2012', '12/10/2012');
+const schema = avDate().between('12/01/2012', '12/10/2012');
 
 schema.isValid('12/02/2012'); // valid
 ```

--- a/packages/yup/moment.js
+++ b/packages/yup/moment.js
@@ -1,8 +1,0 @@
-import * as yup from 'yup';
-import './src/index';
-
-import MomentDate from './src/date';
-import DateRange from './src/dateRange';
-
-yup.avDate = opts => new MomentDate(opts);
-yup.dateRange = opts => new DateRange(opts);

--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -1,4 +1,4 @@
-import * as yup from 'yup';
+import { mixed } from 'yup';
 import moment from 'moment';
 
 const defaultOpts = {
@@ -7,7 +7,7 @@ const defaultOpts = {
 
 const formats = ['YYYY-MM-DD', 'MMDDYYYY', 'YYYYMMDD', 'MM-DD-YYYY'];
 
-export default class AvDateSchema extends yup.mixed {
+export default class AvDateSchema extends mixed {
   constructor({ format = 'MM/DD/YYYY' } = defaultOpts) {
     super({
       type: 'avDate',

--- a/packages/yup/src/dateRange.js
+++ b/packages/yup/src/dateRange.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 import get from 'lodash.get';
-import * as yup from 'yup';
+import { mixed, ValidationError } from 'yup';
 import merge from 'merge-options-es5';
 
 const defaultOptions = {
@@ -13,7 +13,7 @@ const defaultValue = {};
 
 const formats = ['YYYY-MM-DD', 'MMDDYYYY', 'YYYYMMDD'];
 
-export default class DateRangeSchema extends yup.mixed {
+export default class DateRangeSchema extends mixed {
   constructor(options) {
     super({
       type: 'dateRange',
@@ -83,7 +83,7 @@ export default class DateRangeSchema extends yup.mixed {
 
         if (maxValue) {
           if (endDate.isAfter(startDate.add(maxValue, maxUnits), 'day')) {
-            return new yup.ValidationError(
+            return new ValidationError(
               maxErrorMessage ||
                 `The end date must be within ${maxValue} ${maxUnits}${
                   maxValue > 1 ? 's' : ''
@@ -98,7 +98,7 @@ export default class DateRangeSchema extends yup.mixed {
         }
         if (minValue) {
           if (endDate.isBefore(startDate.add(minValue, minUnits), 'day')) {
-            return new yup.ValidationError(
+            return new ValidationError(
               minErrorMessage ||
                 `The end date must be greater than ${minValue} ${minUnits}${
                   minValue > 1 ? 's' : ''
@@ -210,7 +210,7 @@ export default class DateRangeSchema extends yup.mixed {
         }
 
         return errors.length > 0
-          ? new yup.ValidationError(errors, { startDate, endDate }, this.path)
+          ? new ValidationError(errors, { startDate, endDate }, this.path)
           : true;
       },
     });

--- a/packages/yup/src/index.js
+++ b/packages/yup/src/index.js
@@ -2,6 +2,11 @@ import * as yup from 'yup';
 import isRequired from './isRequired';
 import npi from './npi';
 import phone from './phone';
+import AvDate from './date';
+import DateRange from './dateRange';
+
+export const avDate = opts => new AvDate(opts);
+export const dateRange = opts => new DateRange(opts);
 
 yup.addMethod(yup.string, 'isRequired', isRequired);
 yup.addMethod(yup.number, 'isRequired', isRequired);

--- a/packages/yup/src/index.js
+++ b/packages/yup/src/index.js
@@ -1,4 +1,4 @@
-import * as yup from 'yup';
+import { addMethod, array, number, object, string } from 'yup';
 import isRequired from './isRequired';
 import npi from './npi';
 import phone from './phone';
@@ -8,13 +8,13 @@ import DateRange from './dateRange';
 export const avDate = opts => new AvDate(opts);
 export const dateRange = opts => new DateRange(opts);
 
-yup.addMethod(yup.string, 'isRequired', isRequired);
-yup.addMethod(yup.number, 'isRequired', isRequired);
-yup.addMethod(yup.array, 'isRequired', isRequired);
-yup.addMethod(yup.object, 'isRequired', isRequired);
+addMethod(string, 'isRequired', isRequired);
+addMethod(number, 'isRequired', isRequired);
+addMethod(array, 'isRequired', isRequired);
+addMethod(object, 'isRequired', isRequired);
 
-yup.addMethod(yup.string, 'npi', npi);
-yup.addMethod(yup.number, 'npi', npi);
+addMethod(string, 'npi', npi);
+addMethod(number, 'npi', npi);
 
-yup.addMethod(yup.string, 'phone', phone);
-yup.addMethod(yup.number, 'phone', phone);
+addMethod(string, 'phone', phone);
+addMethod(number, 'phone', phone);

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -1,12 +1,11 @@
-import * as yup from 'yup';
-import '../moment';
+import { avDate } from '../src';
 
 const INVALID = 'Date is invalid.';
 
 const defaults = {};
 
 const validate = async (date, { format, min, max, message } = defaults) => {
-  let schema = yup.avDate({
+  let schema = avDate({
     format,
   });
 

--- a/packages/yup/tests/dateRange.test.js
+++ b/packages/yup/tests/dateRange.test.js
@@ -1,9 +1,8 @@
-import * as yup from 'yup';
-import '../moment';
+import { dateRange } from '../src';
 
 describe('DateRange', () => {
   test('start comes before end', async () => {
-    const schema = yup.dateRange();
+    const schema = dateRange();
 
     await expect(
       schema.validate({
@@ -14,7 +13,7 @@ describe('DateRange', () => {
   });
 
   test('Invalid Dates', async () => {
-    const schema = yup.dateRange();
+    const schema = dateRange();
 
     try {
       await schema.validate({
@@ -27,7 +26,7 @@ describe('DateRange', () => {
   });
 
   test('defines min', async () => {
-    const schema = yup.dateRange().min('12/12/2012');
+    const schema = dateRange().min('12/12/2012');
 
     const valid = await schema.isValid({
       startDate: '12/13/2012',
@@ -38,7 +37,7 @@ describe('DateRange', () => {
   });
 
   test('errors on invalid', async () => {
-    const schema = yup.dateRange().min('12/12/2012');
+    const schema = dateRange().min('12/12/2012');
 
     const valid = await schema.isValid({
       startDate: '12/11/2012',
@@ -51,7 +50,7 @@ describe('DateRange', () => {
 
 describe('date', () => {
   test('should validate', async () => {
-    const schema = yup.dateRange().between('12/10/2012', '12/13/2012');
+    const schema = dateRange().between('12/10/2012', '12/13/2012');
 
     const valid = await schema.isValid({
       startDate: '12/11/2012',
@@ -62,12 +61,10 @@ describe('date', () => {
   });
 
   test('should work with custom value keys', async () => {
-    const schema = yup
-      .dateRange({
-        startKey: 'helloDate',
-        endKey: 'worldDate',
-      })
-      .between('12/10/2012', '12/13/2012');
+    const schema = dateRange({
+      startKey: 'helloDate',
+      endKey: 'worldDate',
+    }).between('12/10/2012', '12/13/2012');
 
     const valid = await schema.isValid({
       helloDate: '12/11/2012',
@@ -78,7 +75,7 @@ describe('date', () => {
   });
 
   test('should validate distance', async () => {
-    const schema = yup.dateRange().distance({
+    const schema = dateRange().distance({
       min: {
         value: 5,
         units: 'day',

--- a/packages/yup/tests/isRequired.test.js
+++ b/packages/yup/tests/isRequired.test.js
@@ -1,9 +1,9 @@
-import * as yup from 'yup';
+import { array, number, string } from 'yup';
 import '../src';
 
 describe('isRequired', () => {
   test('should return error on empty input', async () => {
-    const schema = yup.string().isRequired();
+    const schema = string().isRequired();
 
     const valid = await schema.isValid('');
 
@@ -11,7 +11,7 @@ describe('isRequired', () => {
   });
 
   test('should return error on no number', async () => {
-    const schema = yup.number().isRequired();
+    const schema = number().isRequired();
 
     const valid = await schema.isValid(null);
 
@@ -19,7 +19,7 @@ describe('isRequired', () => {
   });
 
   test('should return error on empty array', async () => {
-    const schema = yup.array().isRequired();
+    const schema = array().isRequired();
 
     const valid = await schema.isValid([]);
 
@@ -27,8 +27,7 @@ describe('isRequired', () => {
   });
 
   test('should accept null input', async () => {
-    const schema = yup
-      .string()
+    const schema = string()
       .isRequired(true)
       .nullable();
 
@@ -38,7 +37,7 @@ describe('isRequired', () => {
   });
 
   test('should accept input', async () => {
-    const schema = yup.string().isRequired(true);
+    const schema = string().isRequired(true);
 
     const valid = await schema.isValid('Test');
 
@@ -46,7 +45,7 @@ describe('isRequired', () => {
   });
 
   test('should render custom error message', async () => {
-    const schema = yup.string().isRequired(true, 'Test Error Message');
+    const schema = string().isRequired(true, 'Test Error Message');
 
     await expect(schema.validate()).rejects.toThrow('Test Error Message');
   });

--- a/packages/yup/tests/npi.test.js
+++ b/packages/yup/tests/npi.test.js
@@ -1,9 +1,9 @@
-import * as yup from 'yup';
+import { number, string } from 'yup';
 import '../src';
 
 describe('npi', () => {
   test('should be valid for empty input', async () => {
-    const schema = yup.string().npi();
+    const schema = string().npi();
 
     const valid = await schema.isValid('');
 
@@ -11,7 +11,7 @@ describe('npi', () => {
   });
 
   test('should be valid for no number', async () => {
-    const schema = yup.number().npi();
+    const schema = number().npi();
 
     const valid = await schema.isValid();
 
@@ -19,8 +19,7 @@ describe('npi', () => {
   });
 
   test('should accept null input', async () => {
-    const schema = yup
-      .string()
+    const schema = string()
       .npi()
       .nullable();
 
@@ -30,7 +29,7 @@ describe('npi', () => {
   });
 
   test('should be invalid for invalid input', async () => {
-    const schema = yup.string().npi();
+    const schema = string().npi();
 
     const valid = await schema.isValid('1234');
 
@@ -38,13 +37,13 @@ describe('npi', () => {
   });
 
   test('should be invalid if NPI contains non-digits', async () => {
-    const schema = yup.number().npi();
+    const schema = number().npi();
     const valid = await schema.isValid('i2eh56789o');
     expect(valid).toBe(false);
   });
 
   test('should be invalid if NPI is not 10 digits in length', async () => {
-    const schema = yup.number().npi();
+    const schema = number().npi();
     let valid = await schema.isValid('123456789');
     expect(valid).toBe(false);
 
@@ -53,25 +52,25 @@ describe('npi', () => {
   });
 
   test('should be invalid if NPI does not start with a 1, 2, 3, or 4', async () => {
-    const schema = yup.number().npi();
+    const schema = number().npi();
     const valid = await schema.isValid('5678901234');
     expect(valid).toBe(false);
   });
 
   test('should be invalid if NPI checksum does not match check digit', async () => {
-    const schema = yup.number().npi();
+    const schema = number().npi();
     const valid = await schema.isValid('1234567890');
     expect(valid).toBe(false);
   });
 
   test('should be valid if NPI is valid', async () => {
-    const schema = yup.number().npi();
+    const schema = number().npi();
     const valid = await schema.isValid('1234567893');
     expect(valid).toBe(true);
   });
 
   test('should render custom error message', async () => {
-    const schema = yup.number().npi('Test Error Message');
+    const schema = number().npi('Test Error Message');
 
     await expect(schema.validate('123')).rejects.toThrow('Test Error Message');
   });

--- a/packages/yup/tests/phone.test.js
+++ b/packages/yup/tests/phone.test.js
@@ -1,22 +1,21 @@
-import * as yup from 'yup';
+import { number, string } from 'yup';
 import '../src';
 
 describe('phone', () => {
   test('should accept empty string', async () => {
-    const schema = yup.string().phone();
+    const schema = string().phone();
     const valid = await schema.isValid('');
     expect(valid).toBe(true);
   });
 
   test('should accept no number', async () => {
-    const schema = yup.number().phone();
+    const schema = number().phone();
     const valid = await schema.isValid();
     expect(valid).toBe(true);
   });
 
   test('should accept null input', async () => {
-    const schema = yup
-      .string()
+    const schema = string()
       .phone()
       .nullable();
     const valid = await schema.isValid();
@@ -24,13 +23,13 @@ describe('phone', () => {
   });
 
   test('should not accept less than 10 digits', async () => {
-    const schema = yup.number().phone();
+    const schema = number().phone();
     const valid = await schema.isValid('123456789');
     expect(valid).toBe(false);
   });
 
   test('should accept country code of "+1" and variations', async () => {
-    const schema = yup.string().phone();
+    const schema = string().phone();
     expect(await schema.isValid('+14444444444')).toBe(true);
     expect(await schema.isValid('14444444444')).toBe(true);
     expect(await schema.isValid('+1 4444444444')).toBe(true);
@@ -38,14 +37,14 @@ describe('phone', () => {
   });
 
   test('must be 10 digits without country code', async () => {
-    const schema = yup.number().phone();
+    const schema = number().phone();
     expect(await schema.isValid('4444444444')).toBe(true);
     expect(await schema.isValid('444 444 4444')).toBe(true);
     expect(await schema.isValid('44444444445')).toBe(false);
   });
 
   test('can be formatted', async () => {
-    const schema = yup.string().phone();
+    const schema = string().phone();
     expect(await schema.isValid('(444) 444-4444')).toBe(true);
     expect(await schema.isValid('+1 (444) 444-4444')).toBe(true);
     expect(await schema.isValid('444-444-4444')).toBe(true);
@@ -55,7 +54,7 @@ describe('phone', () => {
   });
 
   test('should display custom error message', async () => {
-    const schema = yup.number().phone('Custom Error Message');
+    const schema = number().phone('Custom Error Message');
     await expect(schema.validate('123321')).rejects.toThrow(
       'Custom Error Message'
     );

--- a/packages/yup/typings/index.d.ts
+++ b/packages/yup/typings/index.d.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup';
-import './dateRange';
-import './date';
+import './dateRange.d.ts';
+import './date.d.ts';
 
 declare module 'yup' {
   interface StringSchema<T extends string | null | undefined = string>


### PR DESCRIPTION
PR fixes issues for `avDate` and `dateRange` where a user may run into a warning like `WARN "export 'avDate' (imported as 'yup') was not found in 'yup'`. The issue mainly seems to affect storybook deploys, but the user shouldn't have to worry about controlling the exact order of their imports.

This introduces a breaking change because it gets rid of the "magic" import in `@availity/yup/moment.js` and makes user import these date validators directly, like:
 ```js
import { avDate } from '@availity/yup'

const schema = avDate().between('12/01/2012', '12/10/2012');

schema.isValid('12/02/2012');
```

This is also similar to a [new proposal](https://twitter.com/monasticpanic/status/1219635860368449536) for `yup`'s API
