### PR TITLE
refactor(analytics-core): fixed issue with hashchange

### DIFF
--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -217,6 +217,11 @@ export default class AvAnalytics {
   };
 
   trackPageView = url => {
+    // hashchanges are an object so we want to grab the new url from it
+    if (typeof url === 'object') {
+      url = url.newURL;
+    }
+
     url = url || window.location.href;
     const promises = [];
     this.plugins.forEach(plugin => {


### PR DESCRIPTION
On first DOM load, the `url` object is `undefined` so we default to the `window.location.href`. However on subsequent hash changes its an object with the `newURL` as a property so we need to strip it for the proper new url to post.