### PR TITLE
feat(api-core): add permission AND/OR logic to organization filter

### DIFF
--- a/packages/api-core/src/resources/README.md
+++ b/packages/api-core/src/resources/README.md
@@ -59,7 +59,7 @@ Get metadata for the various content types for the Spaces platform.
 
 ### `AvOrganizations`
 
-Service that allows you to get logged=in user's active organizations.
+Service that allows you to get logged in user's active organizations.
 
 #### Methods
 
@@ -70,6 +70,10 @@ Returns organizations belonging to the `user`.
 ##### `getOrganizations(config)`
 
 Returns organizations belonging to the logged in user.
+
+##### `postGet(data, config, additionalPostGetArgs)`
+
+Filters the returned organizations by permissions/resources if additionalPostGetArgs are passed
 
 ### `AvProviders`
 

--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -144,9 +144,8 @@ export default class AvOrganizations extends AvApi {
 
     // loop thru the permissionId list of ORs, finding and adding matching orgs in the userPermissions. ANDs are beneath/within the ORs
     const authorizedOrgs = permissionIdsOR.reduce((accum, permissionIdOR) => {
-      let matchedOrgs = {};
       if (Array.isArray(permissionIdOR)) {
-        matchedOrgs = permissionIdOR.reduce(
+        const matchedOrgs = permissionIdOR.reduce(
           (matchedANDOrgsByPerm, permissionIdAND, index) => {
             this.userPermissions[`${permissionIdAND}`].organizations.forEach(
               org => {
@@ -180,6 +179,7 @@ export default class AvOrganizations extends AvApi {
         Object.keys(matchedOrgs).forEach(orgId => {
           if (!accum[orgId]) {
             accum[orgId] = matchedOrgs[orgId];
+            accum[orgId].match = false;
           }
         });
       } else {
@@ -187,6 +187,7 @@ export default class AvOrganizations extends AvApi {
         this.userPermissions[`${permissionIdOR}`].organizations.forEach(org => {
           if (!accum[org.id]) {
             accum[org.id] = org;
+            accum[org.id].match = false;
           } else {
             // add the resources
             accum[org.id].resources = accum[org.id].resources.concat(

--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -131,26 +131,33 @@ export default class AvOrganizations extends AvApi {
       if (Array.isArray(permissionIdOR)) {
         const matchedOrgs = permissionIdOR.reduce(
           (matchedANDOrgsByPerm, permissionIdAND, index) => {
-            this.userPermissions[`${permissionIdAND}`].organizations.forEach(
-              org => {
-                if (index === 0) {
-                  // add the orgs for the first permission
-                  matchedANDOrgsByPerm[org.id] = org;
-                } else if (matchedANDOrgsByPerm[org.id]) {
-                  // if duplicate, add resources
-                  matchedANDOrgsByPerm[org.id].resources = matchedANDOrgsByPerm[
-                    org.id
-                  ].resources.concat(org.resources);
+            if (this.userPermissions[permissionIdAND]) {
+              this.userPermissions[permissionIdAND].organizations.forEach(
+                org => {
+                  if (index === 0) {
+                    // add the orgs for the first permission
+                    matchedANDOrgsByPerm[org.id] = org;
+                  } else if (matchedANDOrgsByPerm[org.id]) {
+                    // if duplicate, add resources
+                    matchedANDOrgsByPerm[
+                      org.id
+                    ].resources = matchedANDOrgsByPerm[org.id].resources.concat(
+                      org.resources
+                    );
+                  }
                 }
-              }
-            );
+              );
+            }
             // filter unmatched orgs out
             matchedANDOrgsByPerm = Object.keys(matchedANDOrgsByPerm)
-              .filter(orgId =>
-                this.userPermissions[permissionIdAND].organizations.some(
-                  org => org.id === orgId
-                )
-              )
+              .filter(orgId => {
+                if (this.userPermissions[permissionIdAND]) {
+                  return this.userPermissions[
+                    permissionIdAND
+                  ].organizations.some(org => org.id === orgId);
+                }
+                return false;
+              })
               .reduce((obj, orgId) => {
                 obj[orgId] = matchedANDOrgsByPerm[orgId];
                 return obj;
@@ -166,8 +173,7 @@ export default class AvOrganizations extends AvApi {
             accum[orgId].match = false;
           }
         });
-      } else {
-        // just one permission, get the orgs under this permission
+      } else if (this.userPermissions[permissionIdOR]) {
         this.userPermissions[permissionIdOR].organizations.forEach(org => {
           if (!accum[org.id]) {
             accum[org.id] = org;

--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -92,11 +92,11 @@ export default class AvOrganizations extends AvApi {
     // resourceIds is passed as readOnly, convert so that we can use Array methods on it
     const resourceIdsArray = Array.isArray(resourceIdsToUse)
       ? resourceIdsToUse
-      : [`${resourceIdsToUse}`];
+      : [resourceIdsToUse];
 
     const permissionIdsOR = Array.isArray(permissionIdsToUse)
       ? permissionIdsToUse
-      : [`${permissionIdsToUse}`];
+      : [permissionIdsToUse];
 
     if (
       region !== this.previousRegionId ||

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -254,7 +254,7 @@ describe('AvOrganizations', () => {
       };
 
       const additionalPostGetArgs = {
-        resourceIds: ['10111', '11000'],
+        resourceIds: [['10111'], ['11000']],
       };
 
       const {
@@ -287,7 +287,7 @@ describe('AvOrganizations', () => {
       };
 
       const additionalPostGetArgs = {
-        resourceIds: '10222',
+        resourceIds: ['10222'],
       };
 
       const {
@@ -318,7 +318,7 @@ describe('AvOrganizations', () => {
       };
 
       const additionalPostGetArgs = {
-        resourceIds: 10222,
+        resourceIds: [10222],
       };
 
       const {
@@ -504,7 +504,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [['7777', '8888']],
-        resourceIds: [['10111', '11000']],
+        resourceIds: [[['10111'], ['11000']]],
       };
 
       const {
@@ -568,7 +568,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [[7777, 8888]],
-        resourceIds: [[[10111, 10222], 11000]],
+        resourceIds: [[[[10111, 10222]], 11000]],
       };
 
       const {
@@ -604,8 +604,8 @@ describe('AvOrganizations', () => {
           [7777, 8888],
         ],
         resourceIds: [
-          [10111, 90000],
-          [10111, 11011],
+          [[10111], [90000]],
+          [[10111], [11011]],
         ],
       };
 
@@ -639,7 +639,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [[7777, 9999]],
-        resourceIds: [[10111, 10222], 99999],
+        resourceIds: [[[[10111, 10222]]], 99999],
       };
 
       const {
@@ -670,7 +670,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [7777],
-        resourceIds: [[10111, 10222]],
+        resourceIds: [[[10111, 10222]]],
       };
 
       const {
@@ -682,6 +682,37 @@ describe('AvOrganizations', () => {
       );
 
       expect(authorizedFilteredOrgs.length).toBe(1);
+    });
+
+    test('should filter organizations by OR resources', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        leimit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [9999, 8888],
+        resourceIds: [[99999, 90000]], // OR for perm 9999, no resources needed for perm 8888
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(3);
     });
   });
 

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -716,6 +716,128 @@ describe('AvOrganizations', () => {
 
       expect(authorizedFilteredOrgs.length).toBe(2);
     });
+
+    test('should not filter organizations by missing permission OR', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        leimit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [9999, 1234],
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(2);
+    });
+
+    test('should filter organizations by missing permission AND', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        leimit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [[9999, 1234]],
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(0);
+    });
+
+    test('should not filter organizations by missing resource OR', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        leimit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [9999],
+        resourceIds: [99999, 11223],
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(1);
+    });
+
+    test('should filter organizations by missing resource AND', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        leimit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [9999],
+        resourceIds: [[99999, 11223]],
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(0);
+    });
   });
 
   describe('sanitizeIds', () => {

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -236,6 +236,7 @@ describe('AvOrganizations', () => {
       expect(api.query).toHaveBeenLastCalledWith(testConfig);
     });
   });
+
   describe('with additionalPostGetArgs', () => {
     test('should filter out org that does not have valid resource', async () => {
       api = new AvOrganizations({
@@ -254,7 +255,7 @@ describe('AvOrganizations', () => {
       };
 
       const additionalPostGetArgs = {
-        resourceIds: [['10111'], ['11000']],
+        resourceIds: ['10111', '11000'],
       };
 
       const {
@@ -318,7 +319,7 @@ describe('AvOrganizations', () => {
       };
 
       const additionalPostGetArgs = {
-        resourceIds: [10222],
+        resourceIds: [10111],
       };
 
       const {
@@ -329,7 +330,7 @@ describe('AvOrganizations', () => {
         data
       );
 
-      expect(authorizedFilteredOrgs.length).toBe(1);
+      expect(authorizedFilteredOrgs.length).toBe(2);
     });
 
     test('should work when permissionId and resourceId are arrays', async () => {
@@ -504,7 +505,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [['7777', '8888']],
-        resourceIds: [[['10111'], ['11000']]],
+        resourceIds: [['10111', '11000']],
       };
 
       const {
@@ -551,6 +552,7 @@ describe('AvOrganizations', () => {
       expect(authorizedFilteredOrgs[0].id).toBe('1435');
     });
 
+    //
     test('should filter organizations by AND permissions + AND resources', async () => {
       api = new AvOrganizations({
         http: mockHttp,
@@ -568,7 +570,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [[7777, 8888]],
-        resourceIds: [[[[10111, 10222]], 11000]],
+        resourceIds: [[10111, 10222, 11000]],
       };
 
       const {
@@ -604,8 +606,8 @@ describe('AvOrganizations', () => {
           [7777, 8888],
         ],
         resourceIds: [
-          [[10111], [90000]],
-          [[10111], [11011]],
+          [10111, 90000],
+          [10111, 11011],
         ],
       };
 
@@ -639,7 +641,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [[7777, 9999]],
-        resourceIds: [[[[10111, 10222]]], 99999],
+        resourceIds: [[10111, 10222, 99999]],
       };
 
       const {
@@ -670,7 +672,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [7777],
-        resourceIds: [[[10111, 10222]]],
+        resourceIds: [[10111, 10222]],
       };
 
       const {
@@ -701,7 +703,7 @@ describe('AvOrganizations', () => {
 
       const additionalPostGetArgs = {
         permissionIds: [9999, 8888],
-        resourceIds: [[99999, 90000]], // OR for perm 9999, no resources needed for perm 8888
+        resourceIds: [99999, 90000], // OR for perm 9999, no resources on 8888 means none are valid
       };
 
       const {
@@ -712,7 +714,7 @@ describe('AvOrganizations', () => {
         data
       );
 
-      expect(authorizedFilteredOrgs.length).toBe(3);
+      expect(authorizedFilteredOrgs.length).toBe(2);
     });
   });
 

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -718,6 +718,30 @@ describe('AvOrganizations', () => {
     });
   });
 
+  describe('sanitizeIds', () => {
+    test('converts arrays/numbers to strings', () => {
+      expect(api.sanitizeIds(7777)).toEqual('7777');
+      expect(api.sanitizeIds([7777])).toEqual(['7777']);
+      expect(api.sanitizeIds([7777, '8888'])).toEqual(['7777', '8888']);
+      expect(api.sanitizeIds('7777')).toEqual('7777');
+      expect(api.sanitizeIds([[7777]])).toEqual([['7777']]);
+      expect(api.sanitizeIds([[7777, 8888], 9999])).toEqual([
+        ['7777', '8888'],
+        '9999',
+      ]);
+      expect(api.sanitizeIds([9999, ''])).toEqual(['9999', '']);
+      expect(
+        api.sanitizeIds([
+          [7777, 9999],
+          [7777, 8888],
+        ])
+      ).toEqual([
+        ['7777', '9999'],
+        ['7777', '8888'],
+      ]);
+    });
+  });
+
   describe('arePermissionsEqual', () => {
     test('works for strings', async () => {
       api = new AvOrganizations({
@@ -727,11 +751,11 @@ describe('AvOrganizations', () => {
         avUsers: mockAvUsers,
         avUserPermissions: mockAvUserPermissions,
       });
-      api.previousPermissionIds = '7777';
-      expect(api.arePermissionsEqual('7777')).toBe(true);
-      expect(api.arePermissionsEqual(7777)).toBe(true);
-      expect(api.arePermissionsEqual([7777])).toBe(true);
-      expect(api.arePermissionsEqual([8888])).toBe(false);
+      api.previousPermissionIds = api.sanitizeIds('7777');
+      expect(api.arePermissionsEqual(api.sanitizeIds('7777'))).toBe(true);
+      expect(api.arePermissionsEqual(api.sanitizeIds(7777))).toBe(true);
+      expect(api.arePermissionsEqual(api.sanitizeIds([7777]))).toBe(true);
+      expect(api.arePermissionsEqual(api.sanitizeIds([8888]))).toBe(false);
     });
 
     test('works for array', async () => {
@@ -742,9 +766,13 @@ describe('AvOrganizations', () => {
         avUsers: mockAvUsers,
         avUserPermissions: mockAvUserPermissions,
       });
-      api.previousPermissionIds = ['7777', '8888'];
-      expect(api.arePermissionsEqual(['8888', '7777'])).toBe(true);
-      expect(api.arePermissionsEqual(['7777', '9999'])).toBe(false);
+      api.previousPermissionIds = api.sanitizeIds(['7777', '8888']);
+      expect(api.arePermissionsEqual(api.sanitizeIds(['8888', '7777']))).toBe(
+        true
+      );
+      expect(api.arePermissionsEqual(api.sanitizeIds(['7777', '9999']))).toBe(
+        false
+      );
     });
 
     test('works for nested array', async () => {
@@ -755,11 +783,19 @@ describe('AvOrganizations', () => {
         avUsers: mockAvUsers,
         avUserPermissions: mockAvUserPermissions,
       });
-      api.previousPermissionIds = [[7777, 8888], [9999]];
-      expect(api.arePermissionsEqual(['8888', '7777', '9999'])).toBe(true);
-      expect(api.arePermissionsEqual([['8888', '7777'], ['9999']])).toBe(true);
-      expect(api.arePermissionsEqual([['7777', '8888']])).toBe(false);
-      expect(api.arePermissionsEqual([['7777', '8888'], ['5555']])).toBe(false);
+      api.previousPermissionIds = api.sanitizeIds([[7777, 8888], [9999]]);
+      expect(
+        api.arePermissionsEqual(api.sanitizeIds(['8888', '7777', '9999']))
+      ).toBe(true);
+      expect(
+        api.arePermissionsEqual(api.sanitizeIds([['8888', '7777'], ['9999']]))
+      ).toBe(true);
+      expect(api.arePermissionsEqual(api.sanitizeIds([['7777', '8888']]))).toBe(
+        false
+      );
+      expect(
+        api.arePermissionsEqual(api.sanitizeIds([['7777', '8888'], ['5555']]))
+      ).toBe(false);
     });
   });
 });

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -41,6 +41,18 @@ const mockPermissions = {
               {
                 id: '10111',
               },
+              {
+                id: '10222',
+              },
+            ],
+          },
+          {
+            id: '2222',
+            name: 'Second Test Org',
+            resources: [
+              {
+                id: '10111',
+              },
             ],
           },
         ],
@@ -51,6 +63,18 @@ const mockPermissions = {
           {
             id: '2222',
             name: 'Second Test Org',
+            resources: [
+              {
+                id: '11000',
+              },
+              {
+                id: '11011',
+              },
+            ],
+          },
+          {
+            id: '1435',
+            name: 'Availity Test Org',
             resources: [
               {
                 id: '11000',
@@ -68,6 +92,15 @@ const mockPermissions = {
             resources: [
               {
                 id: '99999',
+              },
+            ],
+          },
+          {
+            id: '1435',
+            name: 'Availity Test Org',
+            resources: [
+              {
+                id: '90000',
               },
             ],
           },
@@ -91,331 +124,471 @@ describe('AvOrganizations', () => {
     jest.clearAllMocks();
   });
 
-  test('should be defined', () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      config: {},
+  describe('without resourceIds', () => {
+    test('should be defined', () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        config: {},
+      });
+      expect(api).toBeDefined();
     });
-    expect(api).toBeDefined();
+
+    test('should handle no config passed in', () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+      });
+      expect(api).toBeDefined();
+    });
+    test('queryOrganizations() should call query with user.id added to params.userId', () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        config: {},
+      });
+      api.query = jest.fn();
+
+      const userId = 'testUserId';
+      const user = { id: userId };
+      const testConfig = {
+        name: 'testName',
+        params: { otherParam: 'helloWorld' },
+      };
+      const expectedConfig = { ...testConfig };
+      expectedConfig.params.userId = userId;
+
+      api.queryOrganizations(user, testConfig);
+      expect(api.query).toHaveBeenLastCalledWith(expectedConfig);
+    });
+
+    test('queryOrganizations() should handle undefined config param', () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        config: {},
+      });
+      api.query = jest.fn();
+      const userId = 'testUserId';
+      const user = { id: userId };
+      const expectedConfig = { params: { userId } };
+      api.queryOrganizations(user);
+      expect(api.query).toHaveBeenLastCalledWith(expectedConfig);
+    });
+
+    test('getOrganizations() should throw error if no avUsers passed in', () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        config: {},
+      });
+
+      expect(() => {
+        api.getOrganizations();
+      }).toThrow('avUsers must be defined');
+    });
+
+    test('getOrganizations() should call avUsers.me() and then queryOrganizations()', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        config: {},
+      });
+      api.queryOrganizations = jest.fn();
+
+      const testConfig = { name: 'testName' };
+
+      await api.getOrganizations(testConfig);
+      expect(api.queryOrganizations).toHaveBeenLastCalledWith(
+        mockUser,
+        testConfig
+      );
+    });
+
+    test('getOrganizations() should skip call to avUsers.me() when userId provided and then query()', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        config: {},
+      });
+      api.queryOrganizations = jest.fn();
+      api.query = jest.fn();
+
+      const testConfig = { name: 'testName', params: { userId: 'bmoolenaar' } };
+
+      await api.getOrganizations(testConfig);
+
+      expect(api.queryOrganizations).not.toHaveBeenCalled();
+      expect(api.avUsers.me).not.toHaveBeenCalled();
+      expect(api.query).toHaveBeenLastCalledWith(testConfig);
+    });
   });
+  describe('with resourceIds', () => {
+    test('should filter out org that does not have valid resource', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-  test('should handle no config passed in', () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-    });
-    expect(api).toBeDefined();
-  });
-  test('queryOrganizations() should call query with user.id added to params.userId', () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      config: {},
-    });
-    api.query = jest.fn();
+      const data = {
+        limit: 50,
+        offset: 0,
+        permissionId: ['7777', '8888'],
+        region: 'CA',
+      };
 
-    const userId = 'testUserId';
-    const user = { id: userId };
-    const testConfig = {
-      name: 'testName',
-      params: { otherParam: 'helloWorld' },
-    };
-    const expectedConfig = { ...testConfig };
-    expectedConfig.params.userId = userId;
+      const additionalPostGetArgs = {
+        resourceIds: ['10111', '11000'],
+      };
 
-    api.queryOrganizations(user, testConfig);
-    expect(api.query).toHaveBeenLastCalledWith(expectedConfig);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('queryOrganizations() should handle undefined config param', () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      config: {},
-    });
-    api.query = jest.fn();
-    const userId = 'testUserId';
-    const user = { id: userId };
-    const expectedConfig = { params: { userId } };
-    api.queryOrganizations(user);
-    expect(api.query).toHaveBeenLastCalledWith(expectedConfig);
-  });
-
-  test('getOrganizations() should throw error if no avUsers passed in', () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      config: {},
+      expect(authorizedFilteredOrgs.length).toBe(2);
+      expect(authorizedFilteredOrgs[0].id).toBe('1435');
+      expect(authorizedFilteredOrgs[1].id).toBe('2222');
     });
 
-    expect(() => {
-      api.getOrganizations();
-    }).toThrow('avUsers must be defined');
-  });
+    test('should work when permissionId and resourceId are strings', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-  test('getOrganizations() should call avUsers.me() and then queryOrganizations()', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      config: {},
-    });
-    api.queryOrganizations = jest.fn();
+      const data = {
+        limit: 50,
+        offset: 0,
+        permissionId: '7777',
+        region: 'CA',
+      };
 
-    const testConfig = { name: 'testName' };
+      const additionalPostGetArgs = {
+        resourceIds: '10222',
+      };
 
-    await api.getOrganizations(testConfig);
-    expect(api.queryOrganizations).toHaveBeenLastCalledWith(
-      mockUser,
-      testConfig
-    );
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('getOrganizations() should skip call to avUsers.me() when userId provided and then query()', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      config: {},
-    });
-    api.queryOrganizations = jest.fn();
-    api.query = jest.fn();
-
-    const testConfig = { name: 'testName', params: { userId: 'bmoolenaar' } };
-
-    await api.getOrganizations(testConfig);
-
-    expect(api.queryOrganizations).not.toHaveBeenCalled();
-    expect(api.avUsers.me).not.toHaveBeenCalled();
-    expect(api.query).toHaveBeenLastCalledWith(testConfig);
-  });
-
-  test('should filter out org that does not have valid resource', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(1);
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: ['7777', '8888'],
-      region: 'CA',
-    };
+    test('should work when permissionId and resourceId are arrays', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: ['10111', '11000'],
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+        region: 'CA',
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        permissionIds: ['7777'],
+        resourceIds: ['10222'],
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(2);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('should work when permissionId and resourceId are strings', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(1);
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: '7777',
-      region: 'CA',
-    };
+    test('should work when permissionId is an array and resourceId is a string', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: '10111',
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+        permissionId: ['7777'],
+        region: 'CA',
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        resourceIds: '10222',
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(1);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('should work when permissionId and resourceId are arrays', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(1);
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: ['7777'],
-      region: 'CA',
-    };
+    test('should work when permissionId is a string and resourceId is an array', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: ['10111'],
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+        permissionId: '7777',
+        region: 'CA',
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        resourceIds: ['10222'],
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(1);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('should work when permissionId is an array and resourceId is a string', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(1);
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: ['7777'],
-      region: 'CA',
-    };
+    test('should work without region passed in', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: '10111',
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        permissionIds: ['7777'],
+        resourceIds: ['10222'],
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(1);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('should work when permissionId is a string and resourceId is an array', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(1);
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: '7777',
-      region: 'CA',
-    };
+    test('should use org data from avOrganizations and not avUserPermissions', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: ['10111'],
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+        region: 'CA',
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        permissionIds: '7777',
+        resourceIds: ['10222'],
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(1);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('should work without region passed in', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(1);
+      expect(authorizedFilteredOrgs[0].address).toBeDefined();
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: ['7777'],
-    };
+    test('should filter organizations by AND permissions', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: ['10111'],
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+        region: 'CA',
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        permissionIds: [['7777', '8888']],
+        resourceIds: [['10111', '11000']],
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(1);
-  });
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
 
-  test('should  use org data from avOrganizations and not avUserPermissions', async () => {
-    api = new AvOrganizations({
-      http: mockHttp,
-      promise: Promise,
-      merge: mockMerge,
-      avUsers: mockAvUsers,
-      avUserPermissions: mockAvUserPermissions,
+      expect(authorizedFilteredOrgs.length).toBe(2);
+      expect(authorizedFilteredOrgs[0].id).toBe('1435');
+      expect(authorizedFilteredOrgs[1].id).toBe('2222');
     });
 
-    const data = {
-      limit: 50,
-      offset: 0,
-      permissionId: '7777',
-      region: 'CA',
-    };
+    test('should filter organizations by AND permissions + AND resources', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
 
-    const additionalPostGetArgs = {
-      resourceIds: ['10111'],
-    };
+      const data = {
+        limit: 50,
+        offset: 0,
+        region: 'CA',
+      };
 
-    const {
-      data: { authorizedFilteredOrgs },
-    } = await api.getFilteredOrganizations(
-      mockOrg,
-      additionalPostGetArgs,
-      data
-    );
+      const additionalPostGetArgs = {
+        permissionIds: [['7777', '8888']],
+        resourceIds: [[['10111', '10222'], '11000']],
+      };
 
-    expect(authorizedFilteredOrgs.length).toBe(1);
-    expect(authorizedFilteredOrgs[0].address).toBeDefined();
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(1);
+      expect(authorizedFilteredOrgs[0].id).toBe('1435');
+    });
+
+    test('should filter organizations by OR + AND permissions', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        limit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [
+          ['7777', '9999'],
+          ['7777', '8888'],
+        ],
+        resourceIds: [
+          ['10111', '90000'],
+          ['10111', '11011'],
+        ],
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(2);
+      expect(authorizedFilteredOrgs[0].id).toBe('1435');
+      expect(authorizedFilteredOrgs[1].id).toBe('2222');
+    });
+
+    test('should filter organizations by AND permissions + AND resources with no results', async () => {
+      api = new AvOrganizations({
+        http: mockHttp,
+        promise: Promise,
+        merge: mockMerge,
+        avUsers: mockAvUsers,
+        avUserPermissions: mockAvUserPermissions,
+      });
+
+      const data = {
+        limit: 50,
+        offset: 0,
+        region: 'CA',
+      };
+
+      const additionalPostGetArgs = {
+        permissionIds: [['7777', '9999']],
+        resourceIds: [['10111', '10222'], '99999'],
+      };
+
+      const {
+        data: { authorizedFilteredOrgs },
+      } = await api.getFilteredOrganizations(
+        mockOrg,
+        additionalPostGetArgs,
+        data
+      );
+
+      expect(authorizedFilteredOrgs.length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Update getFilteredOrganizations to use AND/OR permission/resource logic