### PR TITLE
feat(api-core): route api calls to on-prem when called from cloud apps

### DIFF
--- a/packages/api-core/src/api.js
+++ b/packages/api-core/src/api.js
@@ -2,6 +2,7 @@ import qs from 'qs';
 import resolveUrl from '@availity/resolve-url';
 
 import API_OPTIONS from './options';
+import resolveHost from './resolve-host';
 
 export default class AvApi {
   constructor({ http, promise, merge, config }) {
@@ -100,6 +101,7 @@ export default class AvApi {
     }
 
     const { path, version, name, url } = config;
+
     let parts = [];
     if (name) {
       parts = ['', path, version, name, id];
@@ -108,10 +110,15 @@ export default class AvApi {
     }
 
     // join parts, remove multiple /'s and trailing /
-    return parts
+    const uri = parts
       .join('/')
       .replace(/[/]+/g, '/')
       .replace(/\/$/, '');
+
+    const hostname = url
+      ? null
+      : resolveHost(config.host, config.window || window);
+    return (hostname ? `https://${hostname}` : '') + uri;
   }
 
   getRequestUrl() {

--- a/packages/api-core/src/ms.js
+++ b/packages/api-core/src/ms.js
@@ -1,5 +1,6 @@
 import AvApi from './api';
 import API_OPTIONS from './options';
+import resolveHost from './resolve-host';
 
 export default class AvMicroservice extends AvApi {
   constructor({ http, promise, merge, config }) {
@@ -19,10 +20,13 @@ export default class AvMicroservice extends AvApi {
     if (id || configId) {
       parts = [path, version || '', name, id || configId];
     }
-    return parts
+    const uri = parts
       .join('/')
       .replace(/[/]+/g, '/')
       .replace(/\/$/, '');
+
+    const hostname = resolveHost(config.host, config.window || window);
+    return (hostname ? `https://${hostname}` : '') + uri;
   }
 
   // polling location is the same url

--- a/packages/api-core/src/options.js
+++ b/packages/api-core/src/options.js
@@ -31,6 +31,9 @@ const API_OPTIONS = {
     },
 
     sessionBust: true,
+
+    // send credentials on CORS requests
+    withCredentials: true,
   },
   MS: {
     // default base segment for Availity API endpoints
@@ -64,6 +67,9 @@ const API_OPTIONS = {
     },
 
     sessionBust: false,
+
+    // send credentials on CORS requests
+    withCredentials: true,
   },
 };
 

--- a/packages/api-core/src/resolve-host.js
+++ b/packages/api-core/src/resolve-host.js
@@ -1,0 +1,27 @@
+import { getSpecificEnv } from '@availity/env-var';
+
+const CLOUD_TO_APP_DOMAINS = {
+  tst: 'test',
+  stg: 'qa',
+  qua: 'qa',
+  prd: '',
+};
+
+export default function resolveHost(host, overrideWindow) {
+  if (host) return host;
+
+  if (
+    /.*?\.(?:aw|az|gc)[n|p|s]\.availity\.com$/.test(
+      overrideWindow.location.hostname
+    )
+  ) {
+    const env = getSpecificEnv(overrideWindow);
+    if (env === 'local') return '';
+
+    const prefix =
+      CLOUD_TO_APP_DOMAINS[env] === undefined ? env : CLOUD_TO_APP_DOMAINS[env];
+    return `${prefix && `${prefix}-`}apps.availity.com`;
+  }
+
+  return '';
+}

--- a/packages/api-core/src/tests/api.test.js
+++ b/packages/api-core/src/tests/api.test.js
@@ -74,6 +74,16 @@ describe('AvApi', () => {
     }).toThrow('[http], [promise], [config], and [merge] must be defined');
   });
 
+  test('AvApi should default to withCredentials set to true', () => {
+    api = new AvApi({
+      http: mockHttp,
+      promise: Promise,
+      merge: mockMerge,
+      config: {},
+    });
+    expect(api.defaultConfig.withCredentials).toBeTruthy();
+  });
+
   test('getQueryResultKey(data) should determine the key for the list within data', () => {
     const mockConfig = {
       name: 'testName',
@@ -481,6 +491,138 @@ describe('AvApi', () => {
         },
       });
       expect(fakeApi.getRequestUrl()).toBe('/api/v1/test');
+    });
+
+    test('should return full URL when host is specified', () => {
+      const testUrl = 'https://apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        host: 'apps.availity.com',
+      };
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return cloud URL when host is specified', () => {
+      const testUrl = 'https://digital.awp.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        host: 'digital.awp.availity.com',
+      };
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return apps when location is prod cloud', () => {
+      const testUrl = 'https://apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awp.availity.com',
+            pathname: '/cdn/prd/spaces/index.html',
+          },
+        },
+      };
+
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return test-apps when location is tst cloud', () => {
+      const testUrl = 'https://test-apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/tst/spaces/index.html',
+          },
+        },
+      };
+
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return qa-apps when location is stg cloud', () => {
+      const testUrl = 'https://qa-apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/stg/spaces/index.html',
+          },
+        },
+      };
+
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return t01-apps when location is t01 cloud', () => {
+      const testUrl = 'https://t01-apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/t01/spaces/index.html',
+          },
+        },
+      };
+
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return relative URL when location host is prod cloud but path is non-prod', () => {
+      const testUrl = '/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awp.availity.com',
+            pathname: '/cdn/tst/spaces/index.html',
+          },
+        },
+      };
+
+      expect(api.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return relative URL when location host is non-prod cloud but path is prod', () => {
+      const testUrl = '/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/prd/spaces/index.html',
+          },
+        },
+      };
+
+      expect(api.getUrl(testConfig)).toBe(testUrl);
     });
   });
 

--- a/packages/api-core/src/tests/ms.test.js
+++ b/packages/api-core/src/tests/ms.test.js
@@ -80,6 +80,16 @@ describe('AvMicroservice', () => {
     expect(ms.config({})).toEqual(testExpectConfig);
   });
 
+  test('should default to withCredentials set to true', () => {
+    ms = new AvMicroservice({
+      http: mockHttp,
+      promise: Promise,
+      merge: mockMerge,
+      config: {},
+    });
+    expect(ms.defaultConfig.withCredentials).toBeTruthy();
+  });
+
   describe('getUrl', () => {
     const mockFinalResponse = 'finalResponse';
     beforeEach(() => {
@@ -136,6 +146,138 @@ describe('AvMicroservice', () => {
       };
       const testExpected = '/api/test';
       expect(ms.getUrl(testConfig)).toBe(testExpected);
+    });
+
+    test('should return full URL when host is specified', () => {
+      const testUrl = 'https://apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        host: 'apps.availity.com',
+      };
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return cloud URL when host is specified', () => {
+      const testUrl = 'https://digital.awp.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        host: 'digital.awp.availity.com',
+      };
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return apps when location is prod cloud', () => {
+      const testUrl = 'https://apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awp.availity.com',
+            pathname: '/cdn/prd/spaces/index.html',
+          },
+        },
+      };
+
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return test-apps when location is tst cloud', () => {
+      const testUrl = 'https://test-apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/tst/spaces/index.html',
+          },
+        },
+      };
+
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return qa-apps when location is stg cloud', () => {
+      const testUrl = 'https://qa-apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/stg/spaces/index.html',
+          },
+        },
+      };
+
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return t01-apps when location is t01 cloud', () => {
+      const testUrl = 'https://t01-apps.availity.com/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/t01/spaces/index.html',
+          },
+        },
+      };
+
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return relative URL when location host is prod cloud but path is non-prod', () => {
+      const testUrl = '/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awp.availity.com',
+            pathname: '/cdn/tst/spaces/index.html',
+          },
+        },
+      };
+
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
+    });
+
+    test('should return relative URL when location host is non-prod cloud but path is prod', () => {
+      const testUrl = '/api/v1/test';
+      const testConfig = {
+        api: true,
+        path: '/api/',
+        version: '/v1/',
+        name: '/test',
+        window: {
+          location: {
+            hostname: 'digital.awn.availity.com',
+            pathname: '/cdn/prd/spaces/index.html',
+          },
+        },
+      };
+
+      expect(ms.getUrl(testConfig)).toBe(testUrl);
     });
   });
 });


### PR DESCRIPTION
This PR is to handle API calls made with relative URLs when the app has been served from Cloudfront.
