### PR TITLE
Feat/dependency check

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "release:canary": "npm run check:packages && lerna publish -c",
     "check": "npm-check -u && lerna exec --bail false --concurrency 1 -- npm-check -u",
     "add": "sh ./scripts/add.sh",
-    "nuke": "npm run remove-locks && yarn clean",
-    "remove-locks": "find . -type f -name 'package-lock.json' -delete",
+    "nuke": "yarn remove-locks && yarn clean",
+    "remove-locks": "find . -type f -name 'yarn.lock' -delete",
     "check:packages": "sh ./scripts/artifactory-check.sh",
     "pub": "lerna exec --bail false --concurrency 1 -- npm publish",
     "new": "plop"
@@ -103,7 +103,8 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "yarn check:packages"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "nuke": "yarn remove-locks && yarn clean",
     "remove-locks": "find . -type f -name 'yarn.lock' -delete",
     "check:packages": "sh ./scripts/artifactory-check.sh",
+    "check:dependencies": "node scripts/check-missing-deps.js",
     "pub": "lerna exec --bail false --concurrency 1 -- npm publish",
     "new": "plop"
   },
@@ -55,6 +56,7 @@
     "codecov": "^3.5.0",
     "conventional-changelog-cli": "^2.0.11",
     "conventional-recommended-bump": "^6.0.0",
+    "dependency-check": "^4.1.0",
     "eslint-config-availity": "^5.2.3",
     "gh-pages": "^2.1.1",
     "husky": "^4.2.1",
@@ -104,7 +106,7 @@
     "hooks": {
       "commit-msg": "commitlint -e $HUSKY_GIT_PARAMS",
       "pre-commit": "lint-staged",
-      "pre-push": "yarn check:packages"
+      "pre-push": "yarn check:dependencies && yarn check:packages"
     }
   }
 }

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -11,6 +11,7 @@
   },
   "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56",
   "dependencies": {
+    "@babel/runtime": "^7.10.2",
     "yup": "^0.28.4"
   }
 }

--- a/packages/api-axios/package.json
+++ b/packages/api-axios/package.json
@@ -7,6 +7,7 @@
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime": "^7.10.2",
     "merge-options-es5": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@availity/env-var": "^1.11.0",
     "@availity/resolve-url": "^1.1.19",
+    "@babel/runtime": "^7.10.2",
     "qs": "^6.5.2"
   },
   "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"

--- a/packages/authorizations-axios/package.json
+++ b/packages/authorizations-axios/package.json
@@ -21,5 +21,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"
+  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56",
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
+  }
 }

--- a/packages/authorizations-core/package.json
+++ b/packages/authorizations-core/package.json
@@ -9,5 +9,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"
+  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56",
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
+  }
 }

--- a/packages/dl-axios/package.json
+++ b/packages/dl-axios/package.json
@@ -25,5 +25,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"
+  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56",
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
+  }
 }

--- a/packages/dl-core/package.json
+++ b/packages/dl-core/package.json
@@ -18,6 +18,7 @@
     "@availity/api-core": "^6.6.1"
   },
   "dependencies": {
+    "@babel/runtime": "^7.10.2",
     "js-file-download": "^0.4.7"
   },
   "publishConfig": {

--- a/packages/exceptions-axios/package.json
+++ b/packages/exceptions-axios/package.json
@@ -17,5 +17,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"
+  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56",
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
+  }
 }

--- a/packages/exceptions-core/package.json
+++ b/packages/exceptions-core/package.json
@@ -16,5 +16,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56"
+  "gitHead": "21b480acb7fc70e240d88451cee8adecb5ddde56",
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
+  }
 }

--- a/packages/message-core/package.json
+++ b/packages/message-core/package.json
@@ -9,5 +9,8 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
   }
 }

--- a/packages/native-form/package.json
+++ b/packages/native-form/package.json
@@ -18,5 +18,8 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
   }
 }

--- a/packages/resolve-url/package.json
+++ b/packages/resolve-url/package.json
@@ -13,5 +13,8 @@
   "license": "MIT",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.10.2"
   }
 }

--- a/packages/upload-core/package.json
+++ b/packages/upload-core/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@availity/resolve-url": "^1.1.19",
+    "@babel/runtime": "^7.10.2",
     "tus-js-client": "1.7.1"
   }
 }

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -28,6 +28,7 @@
     "yup": "^0.28.1"
   },
   "dependencies": {
+    "@babel/runtime": "^7.10.2",
     "lodash.get": "^4.4.2",
     "merge-options-es5": "^1.0.0"
   },

--- a/scripts/artifactory-check.sh
+++ b/scripts/artifactory-check.sh
@@ -12,7 +12,7 @@
 # error out if something fails
 set -e
 
-if grep -R --exclude='*.sh' --exclude-dir='node_modules'  --include='yarn.lock' 'artifactory.availity' ./
+if grep -R --exclude='*.sh' --exclude-dir='node_modules'  --include='yarn.lock' -e 'artifactory.availity' -e 'packages.availity'  ./
 then
   printf "\n"
   printf "   (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c) \n"

--- a/scripts/artifactory-check.sh
+++ b/scripts/artifactory-check.sh
@@ -12,10 +12,10 @@
 # error out if something fails
 set -e
 
-if grep -R --exclude='*.sh' 'artifactory.availity' --include='package-lock.json' ./
+if grep -R --exclude='*.sh' 'artifactory.availity' --include='yarn.lock' ./
 then
   printf "\nOne of your packages contains a dependency from registry: artifactory.availity.com.\n"
-  printf "Please correct this by running 'npm run nuke' and then 'npm install'.\n\n"
+  printf "Please correct this by running 'yarn nuke' and then 'yarn'.\n\n"
   exit 1
 else
   echo "Artifactory Check Passed"

--- a/scripts/artifactory-check.sh
+++ b/scripts/artifactory-check.sh
@@ -12,8 +12,18 @@
 # error out if something fails
 set -e
 
-if grep -R --exclude='*.sh' 'artifactory.availity' --include='yarn.lock' ./
+if grep -R --exclude='*.sh' --exclude-dir='node_modules'  --include='yarn.lock' 'artifactory.availity' ./
 then
+  printf "\n"
+  printf "   (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c)    (c).-.(c) \n"
+  printf "    / ._. \      / ._. \      / ._. \      / ._. \      / ._. \ \n"
+  printf "  __\( Y )/__  __\( Y )/__  __\( Y )/__  __\( Y )/__  __\( Y )/__\n"
+  printf " (_.-/'-'\-._)(_.-/'-'\-._)(_.-/'-'\-._)(_.-/'-'\-._)(_.-/'-'\-._)\n"
+  printf "    || E ||      || R ||      || R ||      || O ||      || R ||\n"
+  printf "  _.' \`-' '._  _.' \`-' '._  _.' \`-' '._  _.' \`-' '._  _.' \`-' '._\n"
+  printf " (.-./\`-'\.-.)(.-./\`-\`\.-.)(.-./\`-\`\.-.)(.-./\`-'\.-.)(.-./\`-\`\.-.)\n"
+  printf "  \`-'     \`-'  \`-'     \`-'  \`-'     \`-'  \`-'     \`-'  \`-'     \`-' \n"
+  printf "\n\n"
   printf "\nOne of your packages contains a dependency from registry: artifactory.availity.com.\n"
   printf "Please correct this by running 'yarn nuke' and then 'yarn'.\n\n"
   exit 1

--- a/scripts/check-missing-deps.js
+++ b/scripts/check-missing-deps.js
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+const check = require('dependency-check');
+const globby = require('globby');
+
+const dependencyAnalyzer = async (args = {}) => {
+  let { ignorePaths = [] } = args;
+  let exitCode = 0;
+  ignorePaths = Array.isArray(ignorePaths) ? ignorePaths : [ignorePaths];
+  const globs = [
+    ...[
+      'packages/**/package.json',
+      '!packages/**/node_modules/**/package.json',
+    ],
+    ...ignorePaths,
+  ];
+  const files = await globby(globs, {
+    absolute: true,
+  });
+
+  await Promise.all(
+    files.map(async file => {
+      const data = await check({
+        path: file,
+        entries: [],
+        noDefaultEntries: false,
+        extensions: ['.js'],
+      });
+
+      const pkg = data.package;
+      const deps = data.used;
+
+      const missing = check.missing(pkg, deps, {
+        excludeDev: false,
+        excludePeer: false,
+        ignore: [
+          `${pkg.name}`, // Can ignore packages that require their own compiled modules
+        ],
+      });
+
+      if (missing.length > 0) {
+        console.log(
+          `Run the following command to add missing packages to ${pkg.name}:
+yarn workspace ${pkg.name} add ${missing.map(m => `${m}`).join(' ')}
+          `
+        );
+        exitCode = 1;
+      }
+    })
+  );
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(exitCode);
+};
+
+dependencyAnalyzer();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,6 +1179,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.2":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/standalone@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.9.5.tgz#aba82195a39a8ed8ae56eacff72cf2bda551a7c3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3216,10 +3216,24 @@ acorn-jsx@^5.0.1, acorn-jsx@^5.2.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
+acorn-node@^1.6.1:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
+  integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
+  dependencies:
+    acorn "^7.0.0"
+    acorn-walk "^7.0.0"
+    xtend "^4.0.2"
+
 acorn-walk@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+
+acorn-walk@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.1.1.tgz#345f0dffad5c735e7373d2fec9a1023e6a44b83e"
+  integrity sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==
 
 acorn@^5.5.3:
   version "5.7.4"
@@ -3230,6 +3244,11 @@ acorn@^6.0.1, acorn@^6.1.1, acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+
+acorn@^7.0.0:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 acorn@^7.1.1:
   version "7.1.1"
@@ -6242,7 +6261,7 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
+debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -6379,6 +6398,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
+  integrity sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
+
 del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
@@ -6425,6 +6449,21 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dependency-check@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/dependency-check/-/dependency-check-4.1.0.tgz#d45405cabb50298f8674fe28ab594c8a5530edff"
+  integrity sha512-nlw+PvhVQwg0gSNNlVUiuRv0765gah9pZEXdQlIFzeSnD85Eex0uM0bkrAWrHdeTzuMGZnR9daxkup/AqqgqzA==
+  dependencies:
+    debug "^4.0.0"
+    detective "^5.0.2"
+    globby "^10.0.1"
+    is-relative "^1.0.0"
+    micromatch "^4.0.2"
+    minimist "^1.2.0"
+    pkg-up "^3.1.0"
+    read-package-json "^2.0.10"
+    resolve "^1.1.7"
 
 deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
@@ -6519,6 +6558,15 @@ detect-port@^1.3.0:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+detective@^5.0.2:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b"
+  integrity sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==
+  dependencies:
+    acorn-node "^1.6.1"
+    defined "^1.0.0"
+    minimist "^1.1.1"
 
 devcert@^1.1.0:
   version "1.1.0"
@@ -14267,6 +14315,13 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -15400,7 +15455,7 @@ read-cmd-shim@^1.0.1:
   dependencies:
     graceful-fs "^4.1.2"
 
-"read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
+"read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.10, read-package-json@^2.0.13:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.1.1.tgz#16aa66c59e7d4dad6288f179dd9295fd59bb98f1"
   integrity sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==
@@ -19202,7 +19257,7 @@ xstate@^4.8.0:
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.9.1.tgz#da883ae0993b129ba0b54592c59b069963b0fe0a"
   integrity sha512-cfNnRaBebnr1tvs0nHBUTyomfJx36+8MWwXceyNTZfjyELMM8nIoiBDcUzfKmpNlnAvs2ZPREos19cw6Zl4nng==
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
This PR adds scripts to `package.json` that run during the `pre-push` phase of a commit. These scripts should block changes if there any missing dependencies for a package or if the lockfile has references to artifactory.

Also adds `@babel/runtime` as an explicit dependency for packages that compile dependencies to `package/lib`. 