### PR TITLE
fix(api-core): fix filteredOrgs arePermissionsEqual check

### DIFF
--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -272,9 +272,10 @@ export default class AvOrganizations extends AvApi {
     }
 
     const idSet = new Set([...permissionArray]);
+    const idSetPrev = new Set([...prevPermissionArray]);
     const idSetCombined = new Set([...permissionArray, ...prevPermissionArray]);
 
-    return idSet.size === idSetCombined.size;
+    return idSet.size === idSetPrev.size && idSet.size === idSetCombined.size;
   }
 
   sanitizeIds(unsanitized) {

--- a/packages/api-core/src/resources/tests/organizations.test.js
+++ b/packages/api-core/src/resources/tests/organizations.test.js
@@ -843,6 +843,11 @@ describe('AvOrganizations', () => {
       expect(api.arePermissionsEqual(api.sanitizeIds(['7777', '9999']))).toBe(
         false
       );
+      expect(api.arePermissionsEqual(api.sanitizeIds(['7777']))).toBe(false);
+      expect(api.arePermissionsEqual(api.sanitizeIds(['8888']))).toBe(false);
+      expect(
+        api.arePermissionsEqual(api.sanitizeIds(['7777', '8888', '9999']))
+      ).toBe(false);
     });
 
     test('works for nested array', async () => {


### PR DESCRIPTION
fixes when calling a superset of the previous permissions is returned as equal