### PR TITLE
fix(yup): avDate fix for edge case invalid date length

### DIFF
--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -28,8 +28,12 @@ export default class AvDateSchema extends mixed {
       message: 'Date is invalid.',
       name: 'typeError',
       test(value) {
-        if (value !== undefined && !this.schema.isType(value)) {
-          return false;
+        if (value !== undefined) {
+          if (!this.schema.isType(value)) {
+            return false;
+          }
+        } else {
+          return true;
         }
         return value.isValid();
       },

--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -31,7 +31,7 @@ export default class AvDateSchema extends mixed {
         if (value !== undefined && !this.schema.isType(value)) {
           return false;
         }
-        return true;
+        return value.isValid();
       },
     });
   }

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -41,6 +41,7 @@ describe('Date', () => {
     await expect(validate('12-2012')).rejects.toThrow(INVALID);
     await expect(validate('12-2012-12')).rejects.toThrow(INVALID);
     await expect(validate('invalid-date')).rejects.toThrow(INVALID);
+    await expect(validate('01/01/20011')).rejects.toThrow(INVALID);
   });
 
   test('min date', async () => {


### PR DESCRIPTION
Discovered an edge case where yup was correctly validating an invalid date format/input (e.g. 01/01/20011), and displaying feedback text, but was *NOT* blocking form submission. Fix made to align behavior with other invalid cases (min/max, required, etc.), and block submission when input is invalid. Also, added tests.