### PR TITLE
fix(api-core): use correct region param for permissions call inside o…

### DIFF
--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -47,13 +47,27 @@ export default class AvOrganizations extends AvApi {
 
   async postGet(data, config, additionalPostGetArgs) {
     if (additionalPostGetArgs) {
+      this.region = undefined;
+
       const { permissionIds } = additionalPostGetArgs;
-      if (permissionIds) {
-        if (typeof data === 'string') {
-          const dataTemp = qs.parse(data);
+      if (typeof data === 'string') {
+        const dataTemp = qs.parse(data);
+        const { region } = dataTemp;
+        if (region) {
+          this.region = region;
+          delete dataTemp.region;
+        }
+        if (permissionIds) {
           dataTemp.permissionId = permissionIds;
-          data = qs.stringify(dataTemp, { arrayFormat: 'repeat' });
-        } else if (typeof data === 'object') {
+        }
+        data = qs.stringify(dataTemp, { arrayFormat: 'repeat' });
+      } else if (typeof data === 'object') {
+        const { region } = data;
+        if (region) {
+          this.region = region;
+          delete data.region;
+        }
+        if (permissionIds) {
           data.permissionId = permissionIds;
         }
       }
@@ -93,7 +107,7 @@ export default class AvOrganizations extends AvApi {
       data = qs.parse(data);
     }
     const { permissionId } = data;
-    const region = data['regions.code'];
+    const { region } = this;
 
     let permissionIdsToUse = permissionIds || permissionId;
     permissionIdsToUse = this.sanitizeIds(permissionIdsToUse);

--- a/packages/api-core/src/resources/organizations.js
+++ b/packages/api-core/src/resources/organizations.js
@@ -92,7 +92,8 @@ export default class AvOrganizations extends AvApi {
     if (typeof data === 'string') {
       data = qs.parse(data);
     }
-    const { permissionId, region } = data;
+    const { permissionId } = data;
+    const region = data['regions.code'];
 
     let permissionIdsToUse = permissionIds || permissionId;
     permissionIdsToUse = this.sanitizeIds(permissionIdsToUse);


### PR DESCRIPTION
Because the correct param to pass a region to `organizations` is `regions.code`, the region isn't currently getting passed to the `axi-user-permissions` request inside of the organizations resource unless the user is incorrectly sending it as `region`.

Christie and I talked about making it so the user could pass either `region` or `regions.code`, but when I was trying to accommodate this it seemed a little messy.