### PR TITLE
fix(yup): avDate.typeError should not display for empty fields

### DIFF
--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -30,12 +30,20 @@ export default class AvDateSchema extends mixed {
       test(value) {
         if (value !== undefined) {
           if (!this.schema.isType(value)) {
-            return false;
+            // Values that do not pass the previous .isType() check are expected to be a moment object
+            // because this.getValidDate(value) will have run. So as long as the passed in value
+            // is defined, moment._i will contain a string value to validate.
+            // If user enters a date and then removes it, should not show a typeError
+            // Note: this does not prevent other tests, like isRequired, from showing messages
+            // If user has touched a required field, error message should still show
+            return value._i === '';
           }
-        } else {
+
+          // When this.schema.isType(value) returns true
+          // we are avDate type with appropriate format
           return true;
         }
-        return value.isValid();
+        return true;
       },
     });
   }

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -42,6 +42,9 @@ describe('Date', () => {
     await expect(validate('12-2012-12')).rejects.toThrow(INVALID);
     await expect(validate('invalid-date')).rejects.toThrow(INVALID);
     await expect(validate('01/01/20011')).rejects.toThrow(INVALID);
+
+    // Allow user to clear date field without showing typeError
+    await expect(validate('')).resolves.toBeTruthy();
   });
 
   test('min date', async () => {


### PR DESCRIPTION
This fix removes a `typeError` message on empty date fields, allowing user to enter a date and then remove it without leaving up an error message because the field had been touched.