### PR TITLE
feat(yup): schemas can define custom typeError msg

### DIFF
--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -8,10 +8,7 @@ const defaultOpts = {
 const formats = ['YYYY-MM-DD', 'MMDDYYYY', 'YYYYMMDD', 'MM-DD-YYYY'];
 
 export default class AvDateSchema extends mixed {
-  constructor({
-    format = 'MM/DD/YYYY',
-    typeErrorMessage = 'Date is invalid.',
-  } = defaultOpts) {
+  constructor({ format = 'MM/DD/YYYY', typeErrorMessage } = defaultOpts) {
     super({
       type: 'avDate',
     });
@@ -21,6 +18,9 @@ export default class AvDateSchema extends mixed {
     this.getValidDate = this.getValidDate.bind(this);
 
     this.withMutation(() => {
+      if (typeErrorMessage) {
+        super.typeError(typeErrorMessage);
+      }
       this.transform(function mutate(value) {
         return this.getValidDate(value);
       });
@@ -28,31 +28,28 @@ export default class AvDateSchema extends mixed {
   }
 
   typeError() {
-    return (
-      this.typeErrorMessage &&
-      this.test({
-        message: this.typeErrorMessage,
-        name: 'typeError',
-        test(value) {
-          if (value !== undefined) {
-            if (!this.schema.isType(value)) {
-              // Values that do not pass the previous .isType() check are expected to be a moment object
-              // because this.getValidDate(value) will have run. So as long as the passed in value
-              // is defined, moment._i will contain a string value to validate.
-              // If user enters a date and then removes it, should not show a typeError
-              // Note: this does not prevent other tests, like isRequired, from showing messages
-              // If user has touched a required field, error message should still show
-              return value._i === '';
-            }
-
-            // When this.schema.isType(value) returns true
-            // we are avDate type with appropriate format
-            return true;
+    return this.test({
+      message: 'Date is invalid.',
+      name: 'typeError',
+      test(value) {
+        if (value !== undefined) {
+          if (!this.schema.isType(value)) {
+            // Values that do not pass the previous .isType() check are expected to be a moment object
+            // because this.getValidDate(value) will have run. So as long as the passed in value
+            // is defined, moment._i will contain a string value to validate.
+            // If user enters a date and then removes it, should not show a typeError
+            // Note: this does not prevent other tests, like isRequired, from showing messages
+            // If user has touched a required field, error message should still show
+            return value._i === '';
           }
+
+          // When this.schema.isType(value) returns true
+          // we are avDate type with appropriate format
           return true;
-        },
-      })
-    );
+        }
+        return true;
+      },
+    });
   }
 
   _typeCheck(value) {

--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -8,12 +8,16 @@ const defaultOpts = {
 const formats = ['YYYY-MM-DD', 'MMDDYYYY', 'YYYYMMDD', 'MM-DD-YYYY'];
 
 export default class AvDateSchema extends mixed {
-  constructor({ format = 'MM/DD/YYYY' } = defaultOpts) {
+  constructor({
+    format = 'MM/DD/YYYY',
+    typeErrorMessage = 'Date is invalid.',
+  } = defaultOpts) {
     super({
       type: 'avDate',
     });
 
     this.format = format;
+    this.typeErrorMessage = typeErrorMessage;
     this.getValidDate = this.getValidDate.bind(this);
 
     this.withMutation(() => {
@@ -24,28 +28,31 @@ export default class AvDateSchema extends mixed {
   }
 
   typeError() {
-    return this.test({
-      message: 'Date is invalid.',
-      name: 'typeError',
-      test(value) {
-        if (value !== undefined) {
-          if (!this.schema.isType(value)) {
-            // Values that do not pass the previous .isType() check are expected to be a moment object
-            // because this.getValidDate(value) will have run. So as long as the passed in value
-            // is defined, moment._i will contain a string value to validate.
-            // If user enters a date and then removes it, should not show a typeError
-            // Note: this does not prevent other tests, like isRequired, from showing messages
-            // If user has touched a required field, error message should still show
-            return value._i === '';
-          }
+    return (
+      this.typeErrorMessage &&
+      this.test({
+        message: this.typeErrorMessage,
+        name: 'typeError',
+        test(value) {
+          if (value !== undefined) {
+            if (!this.schema.isType(value)) {
+              // Values that do not pass the previous .isType() check are expected to be a moment object
+              // because this.getValidDate(value) will have run. So as long as the passed in value
+              // is defined, moment._i will contain a string value to validate.
+              // If user enters a date and then removes it, should not show a typeError
+              // Note: this does not prevent other tests, like isRequired, from showing messages
+              // If user has touched a required field, error message should still show
+              return value._i === '';
+            }
 
-          // When this.schema.isType(value) returns true
-          // we are avDate type with appropriate format
+            // When this.schema.isType(value) returns true
+            // we are avDate type with appropriate format
+            return true;
+          }
           return true;
-        }
-        return true;
-      },
-    });
+        },
+      })
+    );
   }
 
   _typeCheck(value) {

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -6,11 +6,10 @@ const defaults = {};
 
 const validate = async (
   date,
-  { format, min, max, message, typeErrorMessage } = defaults
+  { format, min, max, message, customErrorMessage } = defaults
 ) => {
   let schema = avDate({
     format,
-    typeErrorMessage,
   });
 
   if (min && !max) {
@@ -23,6 +22,10 @@ const validate = async (
 
   if (min && max) {
     schema = schema.between(min, max, message);
+  }
+
+  if (customErrorMessage) {
+    schema = schema.typeError(customErrorMessage);
   }
 
   return schema.validate(date);
@@ -49,14 +52,11 @@ describe('Date', () => {
 
     // Allow user to clear date field without showing typeError
     await expect(validate('')).resolves.toBeTruthy();
-  });
 
-  test('invalid withTypeErrorMessage', async () => {
+    // With custom message
     await expect(
-      validate('invalid-date', {
-        typeErrorMessage: 'Custom Error Message',
-      })
-    ).rejects.toThrow('Custom Error Message');
+      validate('invalid-date', { customErrorMessage: 'custom error message' })
+    ).rejects.toThrow('custom error message');
   });
 
   test('min date', async () => {

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -4,10 +4,14 @@ const INVALID = 'Date is invalid.';
 
 const defaults = {};
 
-const validate = async (date, { format, min, max, message } = defaults) => {
+const validate = async (
+  date,
+  { format, min, max, message, typeErrorMessage } = defaults
+) => {
   let schema = avDate({
     format,
-  });
+    typeErrorMessage,
+  }).typeError();
 
   if (min && !max) {
     schema = schema.min(min, message);
@@ -45,6 +49,14 @@ describe('Date', () => {
 
     // Allow user to clear date field without showing typeError
     await expect(validate('')).resolves.toBeTruthy();
+  });
+
+  test('invalid withTypeErrorMessage', async () => {
+    await expect(
+      validate('invalid-date', {
+        typeErrorMessage: 'Custom Error Message',
+      })
+    ).rejects.toThrow('Custom Error Message');
   });
 
   test('min date', async () => {

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -11,7 +11,7 @@ const validate = async (
   let schema = avDate({
     format,
     typeErrorMessage,
-  }).typeError();
+  });
 
   if (min && !max) {
     schema = schema.min(min, message);


### PR DESCRIPTION
- Add typeErrorMessage to args for avDate() constructor
- Add test for custom typeError message
- Fix tests that broke by running .typeError() after the constructor in the test suite