### PR TITLE
fix(yup): refactor typeError, use _typeCheck

### DIFF
--- a/packages/yup/src/date.js
+++ b/packages/yup/src/date.js
@@ -17,39 +17,21 @@ export default class AvDateSchema extends mixed {
     this.getValidDate = this.getValidDate.bind(this);
 
     this.withMutation(() => {
+      if (!this.tests.some((test) => test?.OPTIONS?.name === 'typeError')) {
+        super.typeError('Date is invalid.');
+      }
       this.transform(function mutate(value) {
         return this.getValidDate(value);
       });
     });
   }
 
-  typeError() {
-    return this.test({
-      message: 'Date is invalid.',
-      name: 'typeError',
-      test(value) {
-        if (value !== undefined) {
-          if (!this.schema.isType(value)) {
-            // Values that do not pass the previous .isType() check are expected to be a moment object
-            // because this.getValidDate(value) will have run. So as long as the passed in value
-            // is defined, moment._i will contain a string value to validate.
-            // If user enters a date and then removes it, should not show a typeError
-            // Note: this does not prevent other tests, like isRequired, from showing messages
-            // If user has touched a required field, error message should still show
-            return value._i === '';
-          }
-
-          // When this.schema.isType(value) returns true
-          // we are avDate type with appropriate format
-          return true;
-        }
-        return true;
-      },
-    });
-  }
-
   _typeCheck(value) {
-    return value.isValid();
+    // So as long as the passed in value is defined, moment._i will contain a string value to validate.
+    // If user enters a date and then removes it, should not show a typeError
+    // Note: this does not prevent other tests, like isRequired, from showing messages
+    // If user has touched a required field, required error message should still show
+    return value.isValid() || value._i === '';
   }
 
   getValidDate(value) {
@@ -107,7 +89,7 @@ export default class AvDateSchema extends mixed {
     });
   }
 
-  between(min, max, msg, inclusivity = '()' ) {
+  between(min, max, msg, inclusivity = '()') {
     const minDate = this.getValidDate(min);
 
     const maxDate = this.getValidDate(max);

--- a/packages/yup/tests/date.test.js
+++ b/packages/yup/tests/date.test.js
@@ -6,7 +6,7 @@ const defaults = {};
 
 const validate = async (
   date,
-  { format, min, max, message, inclusivity } = defaults
+  { format, min, max, message, inclusivity, customErrorMessage } = defaults
 ) => {
   let schema = avDate({
     format,
@@ -24,6 +24,10 @@ const validate = async (
     schema = inclusivity
       ? schema.between(min, max, message, inclusivity)
       : schema.between(min, max, message);
+  }
+
+  if (customErrorMessage) {
+    schema = schema.typeError(customErrorMessage);
   }
 
   return schema.validate(date);
@@ -50,6 +54,11 @@ describe('Date', () => {
 
     // Allow user to clear date field without showing typeError
     await expect(validate('')).resolves.toBeTruthy();
+
+    // With custom message
+    await expect(
+      validate('invalid-date', { customErrorMessage: 'custom error message' })
+    ).rejects.toThrow('custom error message');
   });
 
   test('min date', async () => {


### PR DESCRIPTION
Allows users to utilize .typeError('someCustomMessage')
If .typeError is not utilized, default error message will be 'Date is invalid.'
