### PR TITLE
feat(native-form): call avWebQLApi to obtain sso type

### DIFF
--- a/packages/native-form/index.d.ts
+++ b/packages/native-form/index.d.ts
@@ -1,8 +1,11 @@
+type SsoType = 'saml' | 'openid';
+
 declare function nativeForm(
   spaceId: string,
+  clientId: string,
   params?: { [key: string]: any },
   formAttributes?: { [key: string]: any },
-  type?: string | 'saml'
+  type?: SsoType
 ): void;
 
 export default nativeForm;

--- a/packages/native-form/package.json
+++ b/packages/native-form/package.json
@@ -22,5 +22,13 @@
   "dependencies": {
     "@babel/runtime": "^7.10.2",
     "core-js": "^3.12.1"
+  },
+  "devDependencies": {
+    "@availity/api-axios": "^5.5.14",
+    "@availity/api-core": "^7.0.2"
+  },
+  "peerDependencies": {
+    "@availity/api-axios": "^5.5.14",
+    "@availity/api-core": "^7.0.2"
   }
 }

--- a/packages/native-form/src/index.js
+++ b/packages/native-form/src/index.js
@@ -32,6 +32,7 @@ const nativeForm = async (
         {
           query: ssoTypeQuery,
           variables: { id: spaceId },
+          operationName: 'ssoTypeFindById',
         },
         { headers: { 'X-Client-ID': clientId } }
       );

--- a/packages/native-form/src/index.js
+++ b/packages/native-form/src/index.js
@@ -1,18 +1,63 @@
+import { avWebQLApi } from '@availity/api-axios';
 import flattenObject from './flattenObject';
 
-const required = field => {
+const required = (field) => {
   throw new Error(`${field} is required and was not provided`);
 };
 
-export default (
+const ssoTypeQuery = `
+query ssoTypeFindById($id: ID!){
+  configurationFindOne(id: $id){
+    ...on Saml{
+      type
+    }
+    ...on OpenId{
+      type
+    }
+  }
+}
+`;
+
+const nativeForm = async (
   spaceId = required('spaceId'),
   params = {},
   formAttributes = {},
-  type = 'saml'
+  type,
+  clientId = 'clientId'
 ) => {
+  let typeLower = type?.toLowerCase();
+  if (typeLower !== 'saml' && typeLower !== 'openid') {
+    try {
+      const { data } = await avWebQLApi.create(
+        {
+          query: ssoTypeQuery,
+          variables: { id: spaceId },
+        },
+        { headers: { 'X-Client-ID': clientId } }
+      );
+      typeLower = data?.data?.configurationFindOne?.type?.toLowerCase();
+    } catch (error) {
+      // https://github.com/axios/axios#handling-errors
+      if (error.response) {
+        // The request was made and the server responded with a status code
+        // that falls out of the range of 2xx
+        throw new Error('The server responded with an error');
+      } else if (error.request) {
+        // The request was made but no response was received
+        // `error.request` is an instance of XMLHttpRequest in the browser
+        throw new Error('No response received');
+      } else {
+        // Something happened in setting up the request that triggered an Error
+        throw new Error(
+          'An error occurred while setting up request, check your configurations'
+        );
+      }
+    }
+  }
+
   const mergedOptions = {
     method: 'post',
-    action: `/ms/api/availity/internal/spc/magneto/sso/v1/${type}/${spaceId}`,
+    action: `/ms/api/availity/internal/spc/magneto/sso/v1/${typeLower}/${spaceId}`,
     target: '_blank',
     ...formAttributes,
   };
@@ -22,7 +67,7 @@ export default (
   }
   const flat = flattenObject(params);
   const fields = Object.keys(flat)
-    .map(key => {
+    .map((key) => {
       const name = key.replace(/\[\d+]/g, '[]');
       const value = flat[key];
       return `<input type="hidden" name="${name}" value="${value}" />`;
@@ -30,7 +75,8 @@ export default (
     .join('');
 
   form.insertAdjacentHTML('beforeend', fields);
-  // eslint-disable-next-line unicorn/prefer-node-append
   document.body.appendChild(form);
   form.submit();
 };
+
+export default nativeForm;

--- a/packages/native-form/tests/nativeForm.test.js
+++ b/packages/native-form/tests/nativeForm.test.js
@@ -1,5 +1,8 @@
+import { avWebQLApi } from '@availity/api-axios';
 import nativeForm from '../src';
 import flattenObject from '../src/flattenObject';
+
+jest.mock('@availity/api-axios');
 
 describe('nativeForm', () => {
   const complexObject = {
@@ -40,6 +43,7 @@ describe('nativeForm', () => {
       });
     });
   });
+
   describe('default export', () => {
     beforeEach(() => {
       window.HTMLFormElement.prototype.submit = jest.fn();
@@ -49,103 +53,111 @@ describe('nativeForm', () => {
       const form = document.querySelector('form');
       if (form) form.remove();
     });
-    test('spaceId is required', () => {
-      expect(() => nativeForm()).toThrow(
+
+    test('spaceId is required', async () => {
+      await expect(() => nativeForm()).rejects.toThrow(
         'spaceId is required and was not provided'
       );
     });
 
-    test('create a form', () => {
-      nativeForm('spaceId');
+    test('create a form', async () => {
+      await nativeForm('spaceId', {}, {}, 'saml');
       expect(document.querySelector('form')).not.toBeNull();
     });
 
     describe('the form', () => {
-      test('should be added to the body (to be able to be submitted)', () => {
-        nativeForm('spaceId');
+      test('should be added to the body (to be able to be submitted)', async () => {
+        await nativeForm('spaceId', {}, {}, 'saml');
         expect(document.body.querySelector('form')).not.toBeNull();
       });
 
-      test('action should have the space id in the URL by default', () => {
-        nativeForm('spaceId123');
+      test('action should have the space id in the URL by default', async () => {
+        await nativeForm('spaceId123', {}, {}, 'saml');
         expect(document.querySelector('form').getAttribute('action')).toBe(
           '/ms/api/availity/internal/spc/magneto/sso/v1/saml/spaceId123'
         );
       });
 
-      test('action should be overridable', () => {
-        nativeForm('spaceId123', {}, { action: '/my/url/here' });
+      test('action should be overridable', async () => {
+        await nativeForm('spaceId123', {}, { action: '/my/url/here' }, 'saml');
         expect(document.querySelector('form').getAttribute('action')).toBe(
           '/my/url/here'
         );
       });
 
-      test('action magneto integration type should be overridable', () => {
-        nativeForm('spaceId123', {}, {}, 'openid');
+      test('action magneto integration type should be overridable', async () => {
+        await nativeForm('spaceId123', {}, {}, 'openid');
         expect(document.querySelector('form').getAttribute('action')).toBe(
           '/ms/api/availity/internal/spc/magneto/sso/v1/openid/spaceId123'
         );
       });
 
-      test('method should be post by default', () => {
-        nativeForm('spaceId');
+      test('method should be post by default', async () => {
+        await nativeForm('spaceId', {}, {}, 'saml');
         expect(document.querySelector('form').getAttribute('method')).toBe(
           'post'
         );
       });
 
-      test('method should be overridable', () => {
-        nativeForm('spaceId123', {}, { method: 'get' });
+      test('method should be overridable', async () => {
+        await nativeForm('spaceId123', {}, { method: 'get' }, 'saml');
         expect(document.querySelector('form').getAttribute('method')).toBe(
           'get'
         );
       });
 
-      test('target should be _blank by default', () => {
-        nativeForm('spaceId');
+      test('target should be _blank by default', async () => {
+        await nativeForm('spaceId', {}, {}, 'saml');
         expect(document.querySelector('form').getAttribute('target')).toBe(
           '_blank'
         );
       });
 
-      test('target should be overridable', () => {
-        nativeForm('spaceId123', {}, { target: '_top' });
+      test('target should be overridable', async () => {
+        await nativeForm('spaceId123', {}, { target: '_top' }, 'saml');
         expect(document.querySelector('form').getAttribute('target')).toBe(
           '_top'
         );
       });
 
-      test('addtional attributes can be defined', () => {
-        nativeForm('spaceId123', {}, { id: 'myForm', class: 'my-form' });
+      test('addtional attributes can be defined', async () => {
+        await nativeForm(
+          'spaceId123',
+          {},
+          { id: 'myForm', class: 'my-form' },
+          'saml'
+        );
+
         expect(document.querySelector('form').getAttribute('id')).toBe(
           'myForm'
         );
+
         expect(document.querySelector('form').getAttribute('class')).toBe(
           'my-form'
         );
       });
 
-      test('should have no field if no data was provided', () => {
-        nativeForm('spaceId123');
+      test('should have no field if no data was provided', async () => {
+        await nativeForm('spaceId123', {}, {}, 'saml');
         expect(document.querySelector('input')).toBeNull();
       });
 
-      test('should have fields if was provided', () => {
-        nativeForm('spaceId123', { a: 'b' });
+      test('should have fields if was provided', async () => {
+        await nativeForm('spaceId123', { a: 'b' }, {}, 'saml');
         expect(document.querySelector('input')).not.toBeNull();
       });
 
       describe('the fields', () => {
-        test('should have a field for each piece of data (no more, no less)', () => {
-          nativeForm('spaceId123', complexObject);
+        test('should have a field for each piece of data (no more, no less)', async () => {
+          await nativeForm('spaceId123', complexObject, {}, 'saml');
           expect(document.querySelectorAll('input').length).toBe(
             Object.keys(flattenObject(complexObject)).length
           );
         });
 
-        test('the names will match the flat object, but have the array index value removed (the way the back-end likes it)', () => {
+        test('the names will match the flat object, but have the array index value removed (the way the back-end likes it)', async () => {
           // Note: this causes multiple fields to have the same name, so we have to account for that
-          nativeForm('spaceId123', complexObject);
+          await nativeForm('spaceId123', complexObject, {}, 'saml');
           const flat = flattenObject(complexObject);
           const count = {};
           for (const key of Object.keys(flat)) {
@@ -158,9 +170,9 @@ describe('nativeForm', () => {
           }
         });
 
-        test('data should match the values within the object', () => {
+        test('data should match the values within the object', async () => {
           // Note: this causes multiple fields to have the same name, so we have to account for that
-          nativeForm('spaceId123', complexObject);
+          await nativeForm('spaceId123', complexObject, {}, 'saml');
           const flat = flattenObject(complexObject);
           const count = {};
           for (const key of Object.keys(flat)) {
@@ -176,9 +188,87 @@ describe('nativeForm', () => {
       });
     });
 
-    test('submit the form', () => {
-      nativeForm('spaceId');
+    test('submit the form', async () => {
+      await nativeForm('spaceId', {}, {}, 'saml');
       expect(window.HTMLFormElement.prototype.submit).toHaveBeenCalled();
+    });
+
+    describe('fetch sso type behavior', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      test('skips call to webQL endpoint when type param is saml', async () => {
+        avWebQLApi.create.mockResolvedValue({
+          data: {
+            data: {
+              configurationFindOne: {
+                type: null,
+              },
+            },
+          },
+        });
+
+        await nativeForm('spaceId', {}, {}, 'saml');
+        expect(avWebQLApi.create).toHaveBeenCalledTimes(0);
+        expect(document.querySelector('form').getAttribute('action')).toBe(
+          '/ms/api/availity/internal/spc/magneto/sso/v1/saml/spaceId'
+        );
+      });
+
+      test('skips call to webQL endpoint when type param is openid', async () => {
+        avWebQLApi.create.mockResolvedValue({
+          data: {
+            data: {
+              configurationFindOne: {
+                type: null,
+              },
+            },
+          },
+        });
+
+        await nativeForm('spaceId', {}, {}, 'openid');
+        expect(avWebQLApi.create).toHaveBeenCalledTimes(0);
+        expect(document.querySelector('form').getAttribute('action')).toBe(
+          '/ms/api/availity/internal/spc/magneto/sso/v1/openid/spaceId'
+        );
+      });
+
+      test('calls webQL endpoint when type param is omitted', async () => {
+        avWebQLApi.create.mockResolvedValue({
+          data: {
+            data: {
+              configurationFindOne: {
+                type: 'SAML',
+              },
+            },
+          },
+        });
+
+        await nativeForm('spaceId', {}, {});
+        expect(avWebQLApi.create).toHaveBeenCalledTimes(1);
+        expect(document.querySelector('form').getAttribute('action')).toBe(
+          '/ms/api/availity/internal/spc/magneto/sso/v1/saml/spaceId'
+        );
+      });
+
+      test('calls webQL endpoint when type param is neither saml nor openid', async () => {
+        avWebQLApi.create.mockResolvedValue({
+          data: {
+            data: {
+              configurationFindOne: {
+                type: 'OPENID',
+              },
+            },
+          },
+        });
+
+        await nativeForm('spaceId', {}, {}, 'application');
+        expect(avWebQLApi.create).toHaveBeenCalledTimes(1);
+        expect(document.querySelector('form').getAttribute('action')).toBe(
+          '/ms/api/availity/internal/spc/magneto/sso/v1/openid/spaceId'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: native-form now exports an async function, no longer defaults type
MIGRATION:
 Before: nativeForm(...args);
 After: await nativeForm(...args);
