### PR TITLE
feat(upload-core): add types and run formatter

### DIFF
--- a/packages/upload-core/package.json
+++ b/packages/upload-core/package.json
@@ -4,6 +4,7 @@
   "description": "Wrapper for tus-js-client",
   "main": "lib/upload.js",
   "module": "src/upload.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "test"
   },
@@ -15,14 +16,15 @@
   ],
   "author": "Robert McGuinness <rob.mcguinness@availity.com>",
   "license": "MIT",
-  "peerDependencies": {
-    "tus-js-client": "1.7.1"
-  },
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
+  "peerDependencies": {
     "tus-js-client": "1.7.1"
+  },
+  "devDependencies": {
+    "tus-js-client": "1.7.1",
+    "@types/tus-js-client": "^1.7.0"
   },
   "dependencies": {
     "@availity/resolve-url": "^1.1.21",

--- a/packages/upload-core/src/tests/upload.test.js
+++ b/packages/upload-core/src/tests/upload.test.js
@@ -65,7 +65,7 @@ describe('upload-core', () => {
       expect(() => {
         // eslint-disable-next-line no-new
         new Upload();
-      }).toThrow('[options.file] must be defined and of type File');
+      }).toThrow('[file] must be defined and of type File');
     });
 
     it('should throw error with missing bucket id', () => {
@@ -79,9 +79,7 @@ describe('upload-core', () => {
       const file = Buffer.from('hello world'.split(''));
       file.name = 'fileName.png';
       const upload = new Upload(file, optionsWithRetry);
-      expect(upload.options.retryDelays[0]).toBe(
-        optionsWithRetry.retryDelays[0]
-      );
+      expect(upload.options.retryDelays[0]).toBe(optionsWithRetry.retryDelays[0]);
     });
 
     it('should not start upload if any one of the functions in onPreStart returns false', () => {
@@ -120,9 +118,7 @@ describe('upload-core', () => {
       file.name = 'optionsFile.png';
       const upload = new Upload(file, options);
 
-      expect(upload.options.endpoint).toBe(
-        'https://dev.local/ms/api/availity/internal/core/vault/upload/v1/resumable'
-      );
+      expect(upload.options.endpoint).toBe('https://dev.local/ms/api/availity/internal/core/vault/upload/v1/resumable');
     });
 
     it('should not allow files over maxSize', () => {
@@ -159,10 +155,7 @@ describe('upload-core', () => {
     it('should check filePath for slashes', () => {
       const file1 = Buffer.from('hello world!'.split(''));
       file1.name = '\\bad\\file\\path\\file.pdf';
-      const upload1 = new Upload(
-        file1,
-        Object.assign(options, { stripFileNamePathSegments: false })
-      );
+      const upload1 = new Upload(file1, Object.assign(options, { stripFileNamePathSegments: false }));
       expect(upload1.trimFileName(file1.name)).toBe(file1.name);
 
       const file2 = Buffer.from('hello world!'.split(''));
@@ -193,34 +186,22 @@ describe('upload-core', () => {
     it('should validate file name', () => {
       const file = Buffer.from('hello world'.split(''));
       file.name = 'good file name.pdf';
-      const upload = new Upload(
-        file,
-        Object.assign(options, { allowedFileNameCharacters: 'a-zA-Z0-9_ ' })
-      );
+      const upload = new Upload(file, Object.assign(options, { allowedFileNameCharacters: 'a-zA-Z0-9_ ' }));
       expect(upload.isValidFile()).toBeTruthy();
 
       const file2 = Buffer.from('hello world'.split(''));
       file2.name = 'Bad-file-name.pdf';
-      const upload2 = new Upload(
-        file2,
-        Object.assign(options, { allowedFileNameCharacters: 'a-zA-Z0-9 _' })
-      );
+      const upload2 = new Upload(file2, Object.assign(options, { allowedFileNameCharacters: 'a-zA-Z0-9 _' }));
       expect(upload2.isValidFile()).toBeFalsy();
 
       const file3 = Buffer.from('hello world'.split(''));
       file3.name = '123File(1).xlsx';
-      const upload3 = new Upload(
-        file3,
-        Object.assign(options, { allowedFileNameCharacters: '_a-zA-Z0-9 ' })
-      );
+      const upload3 = new Upload(file3, Object.assign(options, { allowedFileNameCharacters: '_a-zA-Z0-9 ' }));
       expect(upload3.isValidFile()).toBeFalsy();
 
       const file4 = Buffer.from('hello world'.split(''));
       file4.name = 'fileName';
-      const upload4 = new Upload(
-        file4,
-        Object.assign(options, { allowedFileNameCharacters: '_a-zA-Z0-9 ' })
-      );
+      const upload4 = new Upload(file4, Object.assign(options, { allowedFileNameCharacters: '_a-zA-Z0-9 ' }));
       expect(upload4.isValidFile()).toBeTruthy();
     });
 
@@ -232,25 +213,22 @@ describe('upload-core', () => {
       afterEach(() => {
         xhrMock.teardown();
       });
+
       it('should upload a file', () =>
         new Promise((resolve) => {
-          nock('https://dev.local')
-            .post('/ms/api/availity/internal/core/vault/upload/v1/resumable/a/')
-            .reply(
-              201,
-              {},
-              {
-                'tus-resumable': '1.0.0',
-                'upload-expires': 'Fri, 12 Jan 2030 15:54:39 GMT',
-                'transfer-encoding': 'chunked',
-                location: '4611142db7c049bbbe37376583a3f46b',
-              }
-            );
+          nock('https://dev.local').post('/ms/api/availity/internal/core/vault/upload/v1/resumable/a/').reply(
+            201,
+            {},
+            {
+              'tus-resumable': '1.0.0',
+              'upload-expires': 'Fri, 12 Jan 2030 15:54:39 GMT',
+              'transfer-encoding': 'chunked',
+              location: '4611142db7c049bbbe37376583a3f46b',
+            }
+          );
 
           nock('https://dev.local')
-            .patch(
-              '/ms/api/availity/internal/core/vault/upload/v1/resumable/a/4611142db7c049bbbe37376583a3f46b'
-            )
+            .patch('/ms/api/availity/internal/core/vault/upload/v1/resumable/a/4611142db7c049bbbe37376583a3f46b')
             .reply(
               204,
               {},
@@ -259,8 +237,7 @@ describe('upload-core', () => {
                 'upload-expires': 'Fri, 12 Jan 2030 15:54:39 GMT',
                 'transfer-encoding': 'chunked',
                 'Upload-Offset': 12,
-                references:
-                  '["/files/105265/9ee77f6d-9779-4b96-a995-0df47657e504"]',
+                references: '["/files/105265/9ee77f6d-9779-4b96-a995-0df47657e504"]',
               }
             );
 
@@ -284,36 +261,37 @@ describe('upload-core', () => {
 
           upload.start();
         }));
-        it('should pickup upload object on each array of functions in onPreStart', () => {
-          const file = Buffer.from('hello world!');
-          file.name = 'a';
+
+      it('should pickup upload object on each array of functions in onPreStart', () => {
+        const file = Buffer.from('hello world!');
+        file.name = 'a';
         const upload = new Upload(file, {
-          ...optionsWithOnPreStartFail, onPreStart: [(upload) => {
-            expect(upload).toBeDefined()
-            return false;
-          }]
+          ...optionsWithOnPreStartFail,
+          onPreStart: [
+            (upload) => {
+              expect(upload).toBeDefined();
+              return false;
+            },
+          ],
         });
-          upload.start();
-        });
+        upload.start();
+      });
+
       it('should start upload if all the functions in onPreStart returns true', () =>
         new Promise((resolve) => {
-          nock('https://dev.local')
-            .post('/ms/api/availity/internal/core/vault/upload/v1/resumable/a/')
-            .reply(
-              201,
-              {},
-              {
-                'tus-resumable': '1.0.0',
-                'upload-expires': 'Fri, 12 Jan 2030 15:54:39 GMT',
-                'transfer-encoding': 'chunked',
-                location: '4611142db7c049bbbe37376583a3f46b',
-              }
-            );
+          nock('https://dev.local').post('/ms/api/availity/internal/core/vault/upload/v1/resumable/a/').reply(
+            201,
+            {},
+            {
+              'tus-resumable': '1.0.0',
+              'upload-expires': 'Fri, 12 Jan 2030 15:54:39 GMT',
+              'transfer-encoding': 'chunked',
+              location: '4611142db7c049bbbe37376583a3f46b',
+            }
+          );
 
           nock('https://dev.local')
-            .patch(
-              '/ms/api/availity/internal/core/vault/upload/v1/resumable/a/4611142db7c049bbbe37376583a3f46b'
-            )
+            .patch('/ms/api/availity/internal/core/vault/upload/v1/resumable/a/4611142db7c049bbbe37376583a3f46b')
             .reply(
               204,
               {},
@@ -322,8 +300,7 @@ describe('upload-core', () => {
                 'upload-expires': 'Fri, 12 Jan 2030 15:54:39 GMT',
                 'transfer-encoding': 'chunked',
                 'Upload-Offset': 12,
-                references:
-                  '["/files/105265/9ee77f6d-9779-4b96-a995-0df47657e504"]',
+                references: '["/files/105265/9ee77f6d-9779-4b96-a995-0df47657e504"]',
               }
             );
 

--- a/packages/upload-core/src/upload.js
+++ b/packages/upload-core/src/upload.js
@@ -31,14 +31,8 @@ const defaultOptions = {
       }
     }
 
-    const keys = Object.keys(options.metadata || {}).map(
-      (key) => options.metadata[key]
-    );
-    const signature = [
-      attributes.toString().replace(/,/g, ''),
-      options.endpoint,
-      keys,
-    ].join('');
+    const keys = Object.keys(options.metadata || {}).map((key) => options.metadata[key]);
+    const signature = [attributes.toString().replace(/,/g, ''), options.endpoint, keys].join('');
 
     const print = Math.abs(hashCode(signature));
 
@@ -53,7 +47,7 @@ const defaultOptions = {
 class Upload {
   constructor(file, options) {
     if (!file) {
-      throw new Error('[options.file] must be defined and of type File(s)');
+      throw new Error('[file] must be defined and of type File(s)');
     }
 
     if (!options || !options.bucketId) {
@@ -121,8 +115,7 @@ class Upload {
       },
       onSuccess: () => {
         const xhr = this.upload._xhr;
-        this.bytesScanned =
-          Number.parseInt(xhr.getResponseHeader('AV-Scan-Bytes'), 10) || 0;
+        this.bytesScanned = Number.parseInt(xhr.getResponseHeader('AV-Scan-Bytes'), 10) || 0;
         this.percentage = this.getPercentage();
 
         const result = this.getResult(xhr);
@@ -172,18 +165,11 @@ class Upload {
     // eslint-disable-next-line unicorn/prefer-add-event-listener
     xhr.onload = () => {
       if (!this.inStatusCategory(xhr.status, 200)) {
-        this.setError(
-          'rejected',
-          `Invalid status returned: ${xhr.status}`,
-          xhr
-        );
+        this.setError('rejected', `Invalid status returned: ${xhr.status}`, xhr);
         return;
       }
 
-      this.bytesScanned = Number.parseInt(
-        xhr.getResponseHeader('AV-Scan-Bytes'),
-        10
-      );
+      this.bytesScanned = Number.parseInt(xhr.getResponseHeader('AV-Scan-Bytes'), 10);
       this.percentage = this.getPercentage();
 
       const result = this.getResult(xhr);
@@ -238,10 +224,7 @@ class Upload {
   }
 
   getToken() {
-    return document.cookie.replace(
-      /(?:(?:^|.*;\s*)XSRF-TOKEN\s*=\s*([^;]*).*$)|^.*$/,
-      '$1'
-    );
+    return document.cookie.replace(/(?:(?:^|.*;\s*)XSRF-TOKEN\s*=\s*([^;]*).*$)|^.*$/, '$1');
   }
 
   start() {
@@ -280,14 +263,8 @@ class Upload {
       }
     }
 
-    const keys = Object.keys(options.metadata || {}).map(
-      (key) => options.metadata[key]
-    );
-    const signature = [
-      attributes.toString().replace(/,/g, ''),
-      options.endpoint,
-      keys,
-    ].join('');
+    const keys = Object.keys(options.metadata || {}).map((key) => options.metadata[key]);
+    const signature = [attributes.toString().replace(/,/g, ''), options.endpoint, keys].join('');
 
     const print = Math.abs(hashCode(signature));
 
@@ -318,9 +295,7 @@ class Upload {
         return false;
       }
       const fileName = this.file.name;
-      const fileExt = fileName
-        .substring(fileName.lastIndexOf('.'))
-        .toLowerCase();
+      const fileExt = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
 
       for (let i = 0; i < this.options.fileTypes.length; i++) {
         this.options.fileTypes[i] = this.options.fileTypes[i].toLowerCase();
@@ -337,14 +312,8 @@ class Upload {
 
   isAllowedFileNameCharacters() {
     if (this.options.allowedFileNameCharacters) {
-      const fileName = this.file.name.substring(
-        0,
-        this.file.name.lastIndexOf('.')
-      );
-      const regExp = new RegExp(
-        `([^${this.options.allowedFileNameCharacters}])`,
-        'g'
-      );
+      const fileName = this.file.name.substring(0, this.file.name.lastIndexOf('.'));
+      const regExp = new RegExp(`([^${this.options.allowedFileNameCharacters}])`, 'g');
       if (fileName && fileName.match(regExp) !== null) {
         this.setError('rejected', 'File name contains characters not allowed');
         return false;
@@ -355,11 +324,7 @@ class Upload {
   }
 
   isValidFile() {
-    return (
-      this.isAllowedFileNameCharacters() &&
-      this.isAllowedFileTypes() &&
-      this.isValidSize()
-    );
+    return this.isAllowedFileNameCharacters() && this.isAllowedFileTypes() && this.isValidSize();
   }
 
   trimFileName(fileName) {
@@ -392,10 +357,7 @@ class Upload {
 
     if (uploadResult === 'encrypted') {
       // needs pw, isDecrypting, isScanning
-      if (
-        !this.waitForPassword &&
-        (decryptResult === null || decryptResult === 'pending')
-      ) {
+      if (!this.waitForPassword && (decryptResult === null || decryptResult === 'pending')) {
         return { status: 'decrypting', message: msg || 'Decrypting file' };
       }
       if (decryptResult === 'rejected') {

--- a/packages/upload-core/types/index.d.ts
+++ b/packages/upload-core/types/index.d.ts
@@ -1,0 +1,39 @@
+declare class Upload {
+  constructor(file: any, options: any);
+
+  inStatusCategory(status: number, category: number): boolean;
+
+  scan(data: any): void;
+
+  getPercentage(): number;
+
+  getToken(): string;
+
+  start(): void;
+
+  generateId(): string;
+
+  fingerprint(file: any, options?: any, callback?: (arg: null, key: string) => string): string;
+
+  sendPassword(pw: any): void;
+
+  isValidSize(): boolean;
+
+  isAllowedFileTypes(): boolean;
+
+  isAllowedFileNameCharacters(): boolean;
+
+  isValidFile(): boolean;
+
+  trimFileName(fileName: string): string;
+
+  getResult(xhr: any): { status: string; message: string };
+
+  setError(status: string, message: string, err: any): void;
+
+  parseErrorMessage(message: string, err: any): void;
+
+  abort(): void;
+}
+
+export default Upload;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,6 +3427,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/tus-js-client@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@types/tus-js-client/-/tus-js-client-1.7.0.tgz#7340a161117bfa05cf751e1fc88a0a6b55a2b2c0"
+  integrity sha512-bUOPV+dpva01rRVMhZEja0zhWUT0kKGh04IguWT8+volSi5QCGn1i3l8D9XtejHOMlfwbQIExUvXqqpXhfSSpg==
+
 "@types/uglify-js@*":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.0.tgz#1cad8df1fb0b143c5aba08de5712ea9d1ff71124"


### PR DESCRIPTION
I've added types for the `upload-core` package and also added `@types/tus-js-client` as a devDependency.

The types are not fully complete, aka there a few any's, but I want to get something out there to start
