### PR TITLE
chore: update filepaths for new packages

### DIFF
--- a/plop-templates/library/main.test.js.hbs
+++ b/plop-templates/library/main.test.js.hbs
@@ -1,4 +1,4 @@
-const {{pascalCase packageName}} = require('./')
+const {{pascalCase packageName}} = require('../src/{{kebabCase packageName}}')
 
 describe('{{kebabCase packageName}}', () => {
   test('should exist', () => {

--- a/plop-templates/library/package.json.hbs
+++ b/plop-templates/library/package.json.hbs
@@ -2,7 +2,7 @@
   "name": "@availity/{{kebabCase packageName}}",
   "version": "1.0.0-alpha.0",
   "description": "{{packageDescription}}",
-  "main": "{{kebabCase packageName}}.js",
+  "main": "src/{{kebabCase packageName}}.js",
   "keywords": [{{{packageKeywords}}}],
   "author": "{{userFullName}} <{{userEmail}}>",
   "license": "MIT",

--- a/plopfile.js
+++ b/plopfile.js
@@ -29,12 +29,12 @@ module.exports = (plop) => {
     actions: [
       {
         type: 'add',
-        path: 'packages/{{kebabCase packageName}}/{{kebabCase packageName}}.js',
+        path: 'packages/{{kebabCase packageName}}/src/{{kebabCase packageName}}.js',
         templateFile: 'plop-templates/library/main.js.hbs',
       },
       {
         type: 'add',
-        path: 'packages/{{kebabCase packageName}}/{{kebabCase packageName}}.test.js',
+        path: 'packages/{{kebabCase packageName}}/tests/{{kebabCase packageName}}.test.js',
         templateFile: 'plop-templates/library/main.test.js.hbs',
       },
       {


### PR DESCRIPTION
I noticed some errors being thrown if the new package did not match this structure. Also, it seemed like all the other packages matched this structure.
