### PR TITLE
fix(yup): package change for major version update

### DIFF
--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -26,6 +26,5 @@
   "peerDependencies": {
     "moment": "^2.24.0",
     "yup": "^0.32.9"
-  },
-  "gitHead": "7290d74ff71d4ceef68da9ec3cb3f3b036eee8c2"
+  }
 }


### PR DESCRIPTION
BREAKING CHANGE: the version of yup this package requires contains breaking changes from 0.32.0 onward
https://github.com/jquense/yup/blob/375f1b9ed41f5043e123ea87a01a2dfe333c3927/CHANGELOG.md#0320-2020-12-03

Major version bump was missed in #392