### PR TITLE
fix(analytics-core): update types and error msg

### DIFF
--- a/packages/analytics-core/src/analytics.js
+++ b/packages/analytics-core/src/analytics.js
@@ -12,7 +12,7 @@ export default class AvAnalytics {
     // if plugins or promise are undefined,
     // or if either is skipped and pageTracking boolean is used in their place
     if (!plugins || !promise) {
-      throw new Error('[plugins], and [promise] must be defined');
+      throw new Error('[plugins] and [promise] must be defined');
     }
 
     this.plugins = Array.isArray(plugins) ? plugins : [plugins];

--- a/packages/analytics-core/src/tests/analytics.test.js
+++ b/packages/analytics-core/src/tests/analytics.test.js
@@ -23,7 +23,7 @@ describe('AvAnalytics', () => {
   test('AvAnalytics should throw error without plugins or Promise', () => {
     expect(() => {
       mockAvAnalytics = new AvAnalytics();
-    }).toThrow('[plugins], and [promise] must be defined');
+    }).toThrow('[plugins] and [promise] must be defined');
   });
 
   test('AvAnalytics should cast plugins to an array', () => {

--- a/packages/analytics-core/types/analytics.d.ts
+++ b/packages/analytics-core/types/analytics.d.ts
@@ -27,7 +27,7 @@ declare class AvAnalytics {
 
   trackEvent(properties: any): Promise<any[]>;
 
-  trackPageView(url: string): Promise<any[]>;
+  trackPageView(url?: string): Promise<any[]>;
 }
 
 export default AvAnalytics;


### PR DESCRIPTION
Updated the types for the analytics-core package. Marked `url` is optional for `trackPageView`
