### PR TITLE
Feat/date range type error message

### DIFF
--- a/docusaurus/docs/resources/yup.md
+++ b/docusaurus/docs/resources/yup.md
@@ -263,6 +263,35 @@ schema.isValid({
 }); // valid
 ```
 
+### typeError
+
+Sets a custom error message for invalid date ranges to override the 'Start and End Date are required.' default when only one of the start or end date is falsy. Useful when combined with @availity/date Date Range react component that rejects invalid dates.
+
+#### parameters
+- **options** - `object`. typeError options.
+  - **message** - `object`. optional. The custom error message to display 
+
+#### example
+
+```js
+import { dateRange } from '@availity/yup';
+
+const schema = dateRange()
+});
+
+schema.isValid({
+  startDate: '',
+  endDate: '12/03/2012',
+}); // throws 'Start and End Date are required.'
+
+const customErrSchema = dateRange().typeError({message: 'Custom error message'})
+
+customErrSchema.isValid({
+  startDate: '',
+  endDate: '12/03/2012'
+}); // throws 'Custom error message'
+```
+
 ## **avDate**
 
 Similar to the default date yup object and accepts a string or `moment` object instead. See [Date](https://github.com/jquense/yup#date) for `min` and `max`

--- a/docusaurus/docs/resources/yup.md
+++ b/docusaurus/docs/resources/yup.md
@@ -269,7 +269,7 @@ Sets a custom error message for invalid date ranges to override the 'Start and E
 
 #### parameters
 - **options** - `object`. typeError options.
-  - **message** - `object`. optional. The custom error message to display 
+  - **message** - `string`. optional. The custom error message to display 
 
 #### example
 

--- a/packages/yup/src/dateRange.js
+++ b/packages/yup/src/dateRange.js
@@ -150,7 +150,7 @@ export default class DateRangeSchema extends MixedSchema {
     });
   }
 
-  typeError() {
+  typeError({ message }) {
     return this.test({
       name: 'typeError',
       exclusive: true,
@@ -158,7 +158,7 @@ export default class DateRangeSchema extends MixedSchema {
         const errors = [];
 
         if ((!startDate || !endDate) && (startDate || endDate)) {
-          errors.push('Start and End Date are required.');
+          errors.push(message || 'Start and End Date are required.');
         }
 
         if (startDate && endDate && !startDate.isSameOrBefore(endDate)) {

--- a/packages/yup/src/tests/dateRange.test.js
+++ b/packages/yup/src/tests/dateRange.test.js
@@ -23,6 +23,17 @@ describe('DateRange', () => {
     ).rejects.toThrow('Start and End Date are required.');
   });
 
+  test('Custom type error message', async () => {
+    const schema = dateRange().typeError({ message: 'Custom Error Message' });
+
+    await expect(
+      schema.validate({
+        startDate: '',
+        endDate: '12/14/2012',
+      })
+    ).rejects.toThrow('Custom Error Message');
+  });
+
   test('defines min', async () => {
     const schema = dateRange().min('12/12/2012');
 


### PR DESCRIPTION
Trying to get a test like this 
![image](https://user-images.githubusercontent.com/18664731/142280441-8e44a5da-52c0-4fca-9e4a-3a723480870b.png)
to pass similar to how other yup validations like avDate have custom type error messages, and this seemed to be the most straightforward, but limited way. 

Update the docs to note that the inspiration for this is dealing with how @availity/date DateRange component rejects improperly formatted dates and sets formik context for those invalid dates to empty strings, so this recipe allows custom error messages that are very useful in that setting.


