### PR TITLE
fix(api-axios): url creation was not working as expected

### DIFF
--- a/packages/api-axios/src/proxy.js
+++ b/packages/api-axios/src/proxy.js
@@ -7,8 +7,7 @@ export default class AvProxyApi extends AvApi {
     }
 
     super({
-      name: config.tenant,
-      path: `api/v1/proxy`,
+      path: `api/v1/proxy/${config.tenant}`,
       version: '',
       ...config,
     });

--- a/packages/api-axios/src/tests/proxy.test.js
+++ b/packages/api-axios/src/tests/proxy.test.js
@@ -14,7 +14,13 @@ describe('AvProxyApi', () => {
     expect(() => new AvProxyApi()).toThrow('[config.tenant] must be defined');
   });
 
-  test('url should be correct', () => {
-    expect(proxy.getUrl(proxy.config())).toBe('/api/v1/proxy/tenant');
+  test('path is generated in constructor', () => {
+    expect(proxy.config().path).toBe('api/v1/proxy/tenant');
+  });
+
+  test('url is created properly', () => {
+    const api = new AvProxyApi({ tenant: 'foo', name: 'v1/test/bar/baz' });
+
+    expect(api.getRequestUrl()).toBe('/api/v1/proxy/foo/v1/test/bar/baz');
   });
 });


### PR DESCRIPTION
The url was not being created properly. I copied over the logic from api-core, and brought it back into the proxy class
