### PR TITLE
fix(message-core): fix return type for AvMessage.subscribe

### DIFF
--- a/packages/message-core/src/AvMessage.d.ts
+++ b/packages/message-core/src/AvMessage.d.ts
@@ -5,7 +5,7 @@ declare class AvMessage {
 
   public enabled: (value?: boolean) => boolean;
 
-  public subscribe: (eventName?: string, fn: (data?: any) => void) => void;
+  public subscribe: (eventName?: string, fn: (data?: any) => void) => () => void;
 
   public unsubscribe: (eventName?: string) => void;
 


### PR DESCRIPTION
According to [these docs](https://availity.github.io/sdk-js/resources/messaging), the `subscribe` method on AvMessage class returns an unsubscribe function. But the type definitions had it returning void.

This fixes that return type.
