### PR TITLE
feat(yup): update how accepted formats are handled for dates

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.js': ['yarn lint:fix', 'prettier --write'],
+  '*.{js,ts}': ['yarn lint:fix', 'prettier --write'],
 };

--- a/docusaurus/docs/resources/yup.md
+++ b/docusaurus/docs/resources/yup.md
@@ -8,23 +8,28 @@ Method extensions for the [yup](https://github.com/jquense/yup)
 
 ## Install
 
+This package includes `yup` as a dependency in version 4+. In version 3 and earlier you will need to provide `yup` version 0.29.3 or earlier.
+
+If you need to use the `avDate` and `dateRange` schemas then you will have to add `moment` as a dependency.
+
 ### NPM
 
 ```bash
-npm install @availity/yup yup
+npm install @availity/yup
 ```
 
 ### Yarn
 
 ```bash
-yarn add @availity/yup yup
+yarn add @availity/yup
 ```
 
 ## Usage
 
-Import the package in the root of your project somewhere and you will have access to all of the provided yup methods.
+There are two ways to use methods provided in this package. `isRequired`, `npi`, and `phone` will all be added to existing `yup` schemas. On the other hand, `date` and `dateRange` must be imported from the package directly.
 
 ```js
+// This import will add our methods to the existing `yup` schema
 import '@availity/yup';
 import * as yup from 'yup';
 
@@ -33,37 +38,40 @@ const schema = yup.string().isRequired(true, 'This field is required.');
 schema.isValid('12-12-2012');
 ```
 
-If you want to utilize the custom date validators you need to import them directly:
+If you want to utilize the custom date validators you need to import them directly
 
 ```js
+// This import will also add the other methods (npi, phone, isRequired)
+// to the existing `yup` schema
 import { avDate, dateRange } from '@availity/yup';
+import * as yup from 'yup';
 
-const dateSchema = avDate();
-const dateRangeSchema = dateRange({
-  startKey: 'helloDate',
-  endKey: 'worldDate',
-}).between('12/10/2012', '12/13/2012');
+const schema = yup.object().shape({
+  date: avDate(),
+  range: dateRange(),
+});
 
-dateSchema.isValid('12-12-2012');
-dateRangeSchema.isValid({
-  helloDate: '12/11/2012',
-  worldDate: '12/12/2012',
+schema.isValid({
+  date: '12-12-2012',
+  range: {
+    startDate: '12/11/2012',
+    endDate: '12/12/2012',
+  },
 });
 ```
 
-## Table of Contents
-
-- [isRequired](#isrequired-stringarraynumberobject)
-- [npi](#npi-string)
-- [phone](#phone-stringnumber)
-- [dateRange](#daterange)
-- [avDate](#avdate)
-
 ## Methods
 
----
+These methods are added to the existing `yup` schema
 
-### isRequired [**String**,**Array**,**Number**,**Object**]
+### isRequired
+
+This method is added to the following schema
+
+- array
+- number
+- object
+- string
 
 #### Parameters
 
@@ -76,14 +84,30 @@ dateRangeSchema.isValid({
 import '@availity/yup';
 import * as yup from 'yup';
 
-yup.string().isRequired();
-yup.string().isRequired(true, 'Custom Error Message');
-yup.number().isRequired();
-yup.array().isRequired();
-yup.object().isRequired();
+const schema = yup.object().shape({
+  required: {
+    string: yup.string().isRequired(true, 'Custom Error Message'),
+    number: yup.number().isRequired(true, 'Custom Error Message'),
+    array: yup.array().isRequired(true, 'Custom Error Message'),
+    object: yup.object().isRequired(true, 'Custom Error Message'),
+  },
+  optional: {
+    string: yup.string().isRequired(false),
+    number: yup.number().isRequired(false),
+    array: yup.array().isRequired(false),
+    object: yup.object().isRequired(false),
+  },
+});
 ```
 
-### npi [**String**]
+### npi
+
+Validate an NPI (National Provider Identifier)
+
+This method is added to the following schema
+
+- number
+- string
 
 #### Parameters
 
@@ -98,9 +122,14 @@ import * as yup from 'yup';
 const schema = yup.string().npi();
 ```
 
-### phone [**String**,**Number**]
+### phone
 
-Validates a phone number. Must be 10 digits without country code, can be formatted when using string schema.
+Validate a phone number. Must be 10 digits without country code, can be formatted when using string schema.
+
+This method is added to the following schema
+
+- number
+- string
 
 #### Parameters
 
@@ -121,7 +150,7 @@ schema.isValid('+1 444-444-4444'); // true
 schema.isValid('444.444.4444'); // true
 schema.isValid('(444) 444 4444'); // true
 
-const schema = yup.number.phone();
+const schema = yup.number().phone();
 
 schema.isValid('4444444444'); // true
 schema.isValid('444 444 4444'); // true
@@ -129,51 +158,58 @@ schema.isValid('44444444445'); // false
 schema.isValid('+14444444444'); // false
 ```
 
-## Additional Schemas
+## Schema
 
----
+The `avDate` and `dateRange` schema exported from this package are used as you would `string` or `number` from `yup` directly.
 
-## **dateRange**
+### dateRange
 
-Evaluates a date range object.
+Validate a daterange object
 
-### Parameters
+#### Parameters
 
 - **options** - `object`. optional. Range Options.
   - **format** - `string`. optional. The format to parse the dates with.
   - **startKey** - `string`. optional. The key for the start date. Default: `startDate`
   - **endKey** - `string`. optional. The key for the end date. Default: `endDate`
-- **message** - `string`. Optional. Custom error message when invalid. Default: "Date Range is invalid."
 
-### Example
+#### Example
 
 ```js
 import { dateRange } from '@availity/yup';
 
-const dateRangeSchema = dateRange({
-  startKey: 'helloDate',
-  endKey: 'worldDate',
-}).between('12/10/2012', '12/13/2012');
+const schema = dateRange();
 
-dateRangeSchema.isValid({
-  helloDate: '12/11/2012',
-  worldDate: '12/12/2012',
+schema.isValid({
+  startDate: '12/11/2012',
+  endDate: '12/12/2012',
+});
+
+// Schema with custom keys
+const customKeySchema = dateRange({
+  startKey: 'from',
+  endKey: 'to',
+});
+
+customKeySchema.isValid({
+  from: '12/11/2012',
+  to: '12/12/2012',
 });
 ```
 
-### **methods**
+#### Methods
 
-### between
+##### between
 
 Accepts range of dates the date range can fall between.
 
-#### parameters
+##### Parameters
 
 - **minDate** - `string`. **required**. The minimum date.
 - **maxDate** - `string`. **required**. The max date.
 - **message** - `string`. Optional. Custom error message when invalid. Default: "Date Range must be between XX/XX/XXXX and XX/XX/XXXX."
 
-#### example
+##### Example
 
 ```js
 import { dateRange } from '@availity/yup';
@@ -183,19 +219,19 @@ const schema = dateRange().between('12/01/2012', '12/10/2012');
 schema.isValid({
   startDate: '12/02/2012',
   endDate: '12/03/2012',
-}); // valid
+});
 ```
 
-### min
+##### min
 
-Accepts date the date range must start after.
+Set the minimum date the given range must start on or after
 
-#### parameters
+###### Parameters
 
-- **minDate** - `string`. **required**. The minimum date.
+- **min** - `string`. **required**. The minimum date.
 - **message** - `string`. Optional. Custom error message when invalid. Default: "Date Range must start after XX/XX/XXXX"
 
-#### example
+###### Example
 
 ```js
 import { dateRange } from '@availity/yup';
@@ -205,19 +241,19 @@ const schema = dateRange().min('12/01/2012');
 schema.isValid({
   startDate: '12/02/2012',
   endDate: '12/03/2012',
-}); // valid
+});
 ```
 
-### max
+##### max
 
-Accepts date, the date range must start before.
+Set the maximum date the given range must end on or before
 
-#### parameters
+###### Parameters
 
-- **maxDate** - `string`. **required**. The max date.
+- **max** - `string`. **required**. The max date.
 - **message** - `string`. Optional. Custom error message when invalid. Default: "Date Range must start before XX/XX/XXXX"
 
-#### example
+###### Example
 
 ```js
 import { dateRange } from '@availity/yup';
@@ -227,14 +263,14 @@ const schema = dateRange().max('12/10/2012');
 schema.isValid({
   startDate: '12/02/2012',
   endDate: '12/03/2012',
-}); // valid
+});
 ```
 
-### distance
+##### distance
 
 Evaluates if date range is within a set distance
 
-#### parameters
+###### Parameters
 
 - **options** - `object`. **required**. distance options.
   - **min** - `object`. optional. The minimum distance between the date ranges
@@ -245,7 +281,7 @@ Evaluates if date range is within a set distance
     - **units** - `string`. optional. the weight of the value. default `day`
   - **format** - `string`. optional. custom parse format for date validation
 
-#### example
+###### Example
 
 ```js
 import { dateRange } from '@availity/yup';
@@ -260,60 +296,125 @@ const schema = dateRange().distance({
 schema.isValid({
   startDate: '12/02/2012',
   endDate: '12/03/2012',
-}); // valid
+});
 ```
 
-### typeError
+##### typeError
 
 Sets a custom error message for invalid date ranges to override the 'Start and End Date are required.' default when only one of the start or end date is falsy. Useful when combined with @availity/date Date Range react component that rejects invalid dates.
 
-#### parameters
-- **options** - `object`. typeError options.
-  - **message** - `string`. optional. The custom error message to display 
+###### Parameters
 
-#### example
+- **options** - `object`. typeError options.
+  - **message** - `string`. optional. The custom error message to display
+
+###### Example
 
 ```js
 import { dateRange } from '@availity/yup';
 
-const schema = dateRange()
-});
+const schema = dateRange();
 
 schema.isValid({
   startDate: '',
   endDate: '12/03/2012',
 }); // throws 'Start and End Date are required.'
 
-const customErrSchema = dateRange().typeError({message: 'Custom error message'})
+const customErrSchema = dateRange().typeError({ message: 'Custom error message' });
 
 customErrSchema.isValid({
   startDate: '',
-  endDate: '12/03/2012'
+  endDate: '12/03/2012',
 }); // throws 'Custom error message'
 ```
 
-## **avDate**
+### avDate
 
 Similar to the default date yup object and accepts a string or `moment` object instead. See [Date](https://github.com/jquense/yup#date) for `min` and `max`
 
-### **Methods**
+#### Parameters
 
-### between
+- **options** - `object`. optional. Range Options.
+  - **format** - `string | string[]`. optional. Add to the list of accepted formats.
 
-Takes an object of dates the given date must fall between
+#### Methods
 
-#### parameters
+##### between
 
-- **minDate** - `string`. **required**. The minimum date.
-- **maxDate** - `string`. **required**. The max date.
-- **message** - `string`. Optional. Custom error message when invalid. Default: "Date must be between XX/XX/XXXX and XX/XX/XXXX."
+Set the min and max that the date must be inbetween
 
-#### example
+###### Parameters
+
+- **min** - `string`. **required**. The minimum allowed date.
+- **max** - `string`. **required**. The maximum allowed date.
+- **message** - `string`. Optional. Custom error message when invalid. Default: "Date must be between ${min} and ${max}."
+- **inclusivity** - `string`. Optional. Set whether the min and max should be inclusive. Default: "()"
+
+[More information](https://momentjscom.readthedocs.io/en/latest/moment/05-query/06-is-between/) on inclusivity
+
+###### Example
 
 ```js
 import { avDate } from '@availity/yup';
 
 const schema = avDate().between('12/01/2012', '12/10/2012');
 
-schema.isValid('12/02/2012'); // valid
+schema.isValid('12/02/2012');
+```
+
+##### min
+
+Validate the date is on or after the given minimum
+
+###### Parameters
+
+- **min** - `string`. **required**. The minimum date the given value must be on or after.
+- **message** - `string`. Optional. Custom error message when invalid. Default: "Date must be ${min} or later."
+
+###### Example
+
+```js
+import { avDate } from '@availity/yup';
+
+const schema = avDate().min('12/01/2012');
+
+schema.isValid('12/02/2012');
+```
+
+##### max
+
+Validate the date is on or before the given maximum
+
+###### Parameters
+
+- **max** - `string`. **required**. The maximum date the given value must be on or before.
+- **message** - `string`. Optional. Custom error message when invalid. Default: "Date must be ${max} or earlier."
+
+###### Example
+
+```js
+import { avDate } from '@availity/yup';
+
+const schema = avDate().max('12/01/2012');
+
+schema.isValid('11/30/2012');
+```
+
+##### isRequired
+
+Mark the date as required.
+
+###### Parameters
+
+- **isRequired** - `string`. **required**. Whether or not the value is required
+- **message** - `string`. Optional. Custom error message when invalid. Default: "This field is required."
+
+###### Example
+
+```js
+import { avDate } from '@availity/yup';
+
+const schema = avDate().isRequired();
+
+schema.isValid('11/30/2012');
 ```

--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -2,6 +2,9 @@
   "name": "@availity/dinosaurdocs",
   "version": "1.1.5",
   "private": true,
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "scripts": {
     "build": "docusaurus build",
     "clean": "rm -rf .docusaurus/ build/ lib/ node_modules/",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "nx run-many --target=build --all",
+    "build:packages": "nx run-many --target=build --all --exclude=dinosaurdocs",
     "build:docs": "nx build dinosaurdocs",
     "build:affected": "nx affected --target=build",
     "bundlesize": "nx run-many --target=bundlesize --all",

--- a/packages/yup/src/tests/dateRange.test.ts
+++ b/packages/yup/src/tests/dateRange.test.ts
@@ -1,7 +1,6 @@
 import { object, string } from 'yup';
 
-import { dateRange } from '..';
-import DateRangeSchema from '../dateRange';
+import DateRangeSchema, { dateRange } from '../dateRange';
 
 describe('DateRange', () => {
   test('start comes before end', async () => {

--- a/packages/yup/src/tests/npi.test.ts
+++ b/packages/yup/src/tests/npi.test.ts
@@ -41,7 +41,7 @@ describe('npi', () => {
     expect(await stringSchema.isValid('123456789')).toBe(false);
     expect(await stringSchema.isValid('12345678901')).toBe(false);
 
-    const numSchema = string().npi();
+    const numSchema = number().npi();
     expect(await numSchema.isValid(123456789)).toBe(false);
     expect(await numSchema.isValid(12345678901)).toBe(false);
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,8 @@
     "preserveWatchOutput": true,
     "skipLibCheck": true,
     "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": false,
     "lib": ["dom", "ES2015"],
     "module": "ESNext",
     "target": "ES6",


### PR DESCRIPTION
I refactored how the `avDate` and `dateRange` schema work. This fixes errors with chaining the methods. 

I expanded the allowed valid formats. I didn't see why we should arbitrarily limit it as long as `moment` knows how to parse the value properly. 

`avDate` constructor now accepts `typeError` which will set the typeError message. the typeError method from `yup` can still be used as well
