### PR TITLE
build(api-core): add back publishing script

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -21,7 +21,8 @@
     "dev": "tsup src/index.js --format esm,cjs --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "clean": "rm -rf node_modules && rm -rf dist"
+    "clean": "rm -rf node_modules && rm -rf dist",
+    "publish": "yarn npm publish --tolerate-republish --access public"
   },
   "dependencies": {
     "@availity/env-var": "workspace:*",


### PR DESCRIPTION
This will start the publishing of `@availity/api-core` again
