### PR TITLE
feat(api-axios): add allResultKey allowing a specified key to be retu…

### DIFF
--- a/packages/api-axios/src/api.js
+++ b/packages/api-axios/src/api.js
@@ -285,7 +285,8 @@ export default class AvApi {
   async all(config) {
     const response = await this.query(config);
 
-    const key = this.getQueryResultKey(response.data);
+    const { allResultKey } = this.defaultConfig;
+    const key = allResultKey || this.getQueryResultKey(response.data);
     const totalPages = Math.ceil(response.data.totalCount / response.data.limit);
     const result = response.data[key] || [];
 

--- a/packages/api-axios/src/resources/regions.js
+++ b/packages/api-axios/src/resources/regions.js
@@ -8,6 +8,7 @@ export default class AvRegionsApi extends AvApi {
       name: 'regions',
       sessionBust: false,
       pageBust: true,
+      allResultKey: 'regions',
       ...config,
     });
   }

--- a/packages/api-axios/src/tests/api.test.js
+++ b/packages/api-axios/src/tests/api.test.js
@@ -114,6 +114,24 @@ describe('AvAPi', () => {
     const api = new AvApi({});
     expect(api.getResult({ data: ['1', '2', '3'] })).toEqual(['1', '2', '3']);
   });
+
+  test('should use allResultKey if defined', async () => {
+    const query = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        data: {
+          array1: ['1', '2'],
+          array2: ['3', '4'],
+        },
+      })
+    );
+
+    const api = new AvApi({ name: 'test', allResultKey: 'array2' });
+    api.query = query;
+
+    const result = await api.all({});
+    expect(result).toEqual(['3', '4']);
+  });
 });
 
 describe('API Definitions', () => {


### PR DESCRIPTION
…rned from AvApi.all()

Currently there is no way to specify what key to use when `resource.all()` is called to fetch all results, it will just return the first Array. We ran into this issue using `AvRegionSelect` because when you pass the `userId` param two arrays are returned in the response.

This change would allow a config to specify the key to be used when `all()` is called.