### PR TITLE
fix(api-axios): override getQueryResultKey for regions

### DIFF
--- a/packages/api-axios/src/resources/regions.js
+++ b/packages/api-axios/src/resources/regions.js
@@ -12,6 +12,10 @@ export default class AvRegionsApi extends AvApi {
     });
   }
 
+  getQueryResultKey() {
+    return 'regions';
+  }
+
   afterUpdate = (response) => {
     this.setPageBust();
     return response;

--- a/packages/api-axios/src/resources/tests/regions.test.js
+++ b/packages/api-axios/src/resources/tests/regions.test.js
@@ -85,4 +85,18 @@ describe('AvRegionsApi', () => {
     api.getCurrentRegion();
     expect(api.query).toHaveBeenLastCalledWith(expectedConfig);
   });
+
+  test('should get correct result when all() is called', async () => {
+    api.query = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        data: {
+          regionAggregations: [],
+          regions: [{ id: 'FL', value: 'Florida' }],
+        },
+      })
+    );
+
+    expect(await api.all()).toEqual([{ id: 'FL', value: 'Florida' }]);
+  });
 });


### PR DESCRIPTION
`AvRegionSelect` will currently use the wrong data from the response if the param `userId` is passed. This change ensures the `regions` array is returned when `all()` is called.