### PR TITLE
feat(env-var): allow users to return undefined

### DIFF
--- a/packages/env-var/src/index.js
+++ b/packages/env-var/src/index.js
@@ -124,7 +124,7 @@ export function getSpecificEnv(windowOverride = window) {
 export default function (varObj, windowOverride, defaultVar) {
   const env = getCurrentEnv(windowOverride);
 
-  if (typeof varObj[env] !== 'undefined') {
+  if (`${env}` in varObj) {
     return varObj[env];
   }
 


### PR DESCRIPTION
i needed to return undefined and i couldn't so i made this

alternately: we could error locally and warn in non-prod if developer tries to use undefined