### PR TITLE
fix(dl-axios): v1.x of axios broke an import, update this class

### DIFF
--- a/packages/dl-axios/src/download.js
+++ b/packages/dl-axios/src/download.js
@@ -1,16 +1,12 @@
-import axios from 'axios';
-import utils from 'axios/lib/utils';
 import DownloadMicroservice from '@availity/dl-core';
 
-const { merge } = utils;
-
 export default class AvDownloadApi extends DownloadMicroservice {
-  constructor(options) {
+  constructor({ http, promise, merge, config }) {
     super({
-      http: axios,
-      promise: Promise,
+      http,
+      promise,
       merge,
-      config: options,
+      config,
     });
   }
 }


### PR DESCRIPTION
Getting the below error when trying to start a react app using axios 1.5.0 and dl-axios 5.0.1

ERROR in ../../node_modules/@availity/dl-axios/dist/index.js 31:27-53
Module not found: Error: Package path ./lib/utils is not exported from package ../node_modules/axios (see exports field in ../node_modules/axios/package.json)

The axios v1 bump from dl-axios v5 did not account for the change in hidden util functions. Although I don't think we have any need to use axios's merge. Updated this resource to be consistent with our other resources