### PR TITLE
Fix/dl axios

### DIFF
--- a/packages/dl-axios/package.json
+++ b/packages/dl-axios/package.json
@@ -32,7 +32,8 @@
     "publish": "yarn npm publish --tolerate-republish --access public"
   },
   "dependencies": {
-    "@availity/dl-core": "workspace:*"
+    "@availity/dl-core": "workspace:*",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "axios": "^1.4.0",
@@ -40,7 +41,7 @@
     "typescript": "^5.1.6"
   },
   "peerDependencies": {
-    "axios": "^0.21.1"
+    "axios": "^1.4.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dl-axios/src/download.js
+++ b/packages/dl-axios/src/download.js
@@ -1,12 +1,14 @@
+import axios from 'axios';
+import merge from 'lodash/merge';
 import DownloadMicroservice from '@availity/dl-core';
 
 export default class AvDownloadApi extends DownloadMicroservice {
-  constructor({ http, promise, merge, config }) {
+  constructor(options) {
     super({
-      http,
-      promise,
+      http: axios,
+      promise: Promise,
       merge,
-      config,
+      config: options,
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -411,10 +411,11 @@ __metadata:
   dependencies:
     "@availity/dl-core": "workspace:*"
     axios: ^1.4.0
+    lodash: ^4.17.21
     tsup: ^7.2.0
     typescript: ^5.1.6
   peerDependencies:
-    axios: ^0.21.1
+    axios: ^1.4.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The last update to dl-axios seems to have accidentally introduced a breaking change. The current version works if you initialize with `http`, `promise`, `merge` and `config` but these weren't previously required.

https://github.com/Availity/sdk-js/pull/599/files

This change fixes the broken import that happened with the axios upgrade without a breaking change.
