### PR TITLE
fix(api-axios): use newConfig.pollingMethod as polling method

### DIFF
--- a/packages/api-axios/src/api.js
+++ b/packages/api-axios/src/api.js
@@ -153,7 +153,7 @@ export default class AvApi {
       const pollingUrl = this.getLocation(response);
 
       if (pollingUrl) {
-        newConfig.method = this.defaultConfig.pollingMethod;
+        newConfig.method = newConfig.pollingMethod;
         newConfig.url = pollingUrl;
         newConfig.cache = false;
 


### PR DESCRIPTION
This ensures that the pollingMethod specified in the request config is respected. 