### PR TITLE
fix(dl-axios): revert back to default export to avoid a breaking change

### DIFF
--- a/packages/dl-axios/src/index.js
+++ b/packages/dl-axios/src/index.js
@@ -1,1 +1,4 @@
-export {default as AvDownloadApi} from './download';
+import AvDownloadApi from './download';
+
+// eslint-disable-next-line unicorn/prefer-export-from
+export default AvDownloadApi;


### PR DESCRIPTION
This export was probably refactored after updating eslint-config-availity caused an error here, but this changed the export from being default to named. Any projects using the old default import would be broken by this change.