### PR TITLE
feat(user-activity-broadcaster): fixing default package main path EB-719

### DIFF
--- a/packages/user-activity-broadcaster/package.json
+++ b/packages/user-activity-broadcaster/package.json
@@ -2,7 +2,7 @@
   "name": "@availity/user-activity-broadcaster",
   "version": "0.1.0",
   "description": "This package broacasts user activity to the navigation.",
-  "main": "src/user-activity-broadcaster.js",
+  "main": "src/index.js",
   "keywords": [],
   "author": "Joe Spanbauer <joseph.spanbauer@availity.com>",
   "engines": {


### PR DESCRIPTION
I forgot that I had to change it to index.js after it auto-generated, to fix another issue. We could leave it, but I rather not have to have folks do this:

> import "@availity/user-activity-broadcaster/src"