### PR TITLE
Feat/upload core build

### DIFF
--- a/.adiorc.js
+++ b/.adiorc.js
@@ -1,7 +1,7 @@
 module.exports = {
   packages: ['packages/*'],
   ignore: {
-    src: ['form-data', 'nock', 'xhr-mock', 'ts-jest'],
+    src: ['form-data', 'nock', 'xhr-mock', 'ts-jest', 'http', 'https', 'url', 'stream'],
     devDependencies: ['typescript', 'tsup', 'axios', '@types/tus-js-client'],
     peerDependencies: ['axios'],
   },

--- a/packages/upload-core/package.json
+++ b/packages/upload-core/package.json
@@ -35,12 +35,12 @@
     "publish": "yarn npm publish --tolerate-republish --access public"
   },
   "dependencies": {
-    "@availity/resolve-url": "workspace:*",
-    "tus-js-client": "1.7.1"
+    "@availity/resolve-url": "workspace:*"
   },
   "devDependencies": {
     "@types/tus-js-client": "^1.7.0",
     "tsup": "^7.2.0",
+    "tus-js-client": "1.7.1",
     "typescript": "^5.5.4"
   },
   "publishConfig": {

--- a/packages/upload-core/src/index.d.ts
+++ b/packages/upload-core/src/index.d.ts
@@ -84,11 +84,9 @@ declare class Upload {
 
   parseErrorMessage(message: string, error?: Error): void;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  scan(data: any): void;
+  scan(data?: { header: string; value: string }): void;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sendPassword(pw: any): void;
+  sendPassword(pw: string): void;
 
   setError(status: string, message: string, error?: Error): void;
 


### PR DESCRIPTION
Moving `tus-js-client` to `devDep` makes it bundled with the final output. This will fix an issue with rollup bundling in Element.
