### PR TITLE
fix(api-axios): allow absolute urls

### DIFF
--- a/packages/api-axios/src/ms.js
+++ b/packages/api-axios/src/ms.js
@@ -10,15 +10,26 @@ export default class AvMicroserviceApi extends AvApi {
     this.defaultConfig = merge({}, API_OPTIONS.MS, options);
   }
 
-  // Override aries 1 url concatenation
   getUrl(config, id = '') {
-    const { path, version, name, id: configId } = this.config(config);
-    let parts = [path, version || '', name];
+    const { path, version, name, id: configId, url } = this.config(config);
+
+    const parts = url ? [url, path, version || '', name] : [path, version || '', name];
 
     if (id || configId) {
-      parts = [path, version || '', name, id || configId];
+      parts.push(id || configId);
     }
 
-    return parts.join('/').replaceAll(/\/+/g, '/').replace(/\/$/, '');
+    // Filter out empty strings and join with slashes
+    const newUrl = parts.join('/');
+
+    if (url) {
+      // Clean up absolute URLs
+      return newUrl.replaceAll(/([^:]\/)\/+/g, '$1'); // Remove multiple slashes but preserve https://
+    }
+    // Clean up relative URLs
+    return newUrl
+      .replaceAll(/\/+/g, '/') // Replace multiple slashes with single slash
+      .replace(/^\/+/, '/') // Ensure single leading slash
+      .replace(/\/+$/, ''); // Remove trailing slash
   }
 }

--- a/packages/api-axios/src/tests/ms.test.js
+++ b/packages/api-axios/src/tests/ms.test.js
@@ -11,6 +11,13 @@ describe('AvMicroserviceAPi', () => {
   });
 
   test('url should be correct', () => {
-    expect(ms.getUrl(ms.config())).toBe('/ms/api/availity/internal/urlPath');
+    expect(ms.getRequestUrl()).toBe('/ms/api/availity/internal/urlPath');
+  });
+
+  test('should use an absolute url', () => {
+    const api = new AvMicroserviceApi({ url: 'http://test-apps.com' });
+
+    expect(api.getRequestUrl()).toBe('http://test-apps.com/ms/api/availity/internal/');
+    expect(api.getUrl({ id: 'serviceName' })).toBe('http://test-apps.com/ms/api/availity/internal/serviceName');
   });
 });


### PR DESCRIPTION
Allow for absolute urls to be used with AvMicroserviceApi
