### PR TITLE
fix(native-form): allow any sso type

### DIFF
--- a/packages/native-form/src/index.d.ts
+++ b/packages/native-form/src/index.d.ts
@@ -6,7 +6,7 @@ declare function nativeForm(
   spaceId: string,
   params?: Record<string, any>,
   formAttributes?: Record<string, any>,
-  type?: SsoType,
+  type?: SsoType | string,
   clientId?: string
 ): Promise<void>;
 


### PR DESCRIPTION
Mui spaces-link actually uses the TS checks and native form should accept types besides 'saml' and 'openid' so we can actually use the logic that fetches the saml config by id