### PR TITLE
chore: disables sessionBust by default

### DIFF
--- a/packages/api-axios/src/options.js
+++ b/packages/api-axios/src/options.js
@@ -30,7 +30,7 @@ const API_OPTIONS = {
       'X-Response-Encoding-Context': 'NONE',
     },
 
-    sessionBust: true,
+    sessionBust: false,
 
     // send credentials on CORS requests
     withCredentials: true,


### PR DESCRIPTION
There have been many changes over the years to make the need for this and the cacheBust param irrelevant. Disabling by default so more API responses can be properly cached by clients
