### PR TITLE
Build/remove cjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log
 .nx/workspace-data
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
+
+.kiro/

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -31,7 +31,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/analytics-core/package.json
+++ b/packages/analytics-core/package.json
@@ -18,23 +18,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/api-axios/package.json
+++ b/packages/api-axios/package.json
@@ -19,23 +19,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/api-axios/package.json
+++ b/packages/api-axios/package.json
@@ -32,7 +32,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -20,23 +20,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -33,7 +33,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/authorizations-axios/package.json
+++ b/packages/authorizations-axios/package.json
@@ -14,23 +14,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/authorizations-axios/package.json
+++ b/packages/authorizations-axios/package.json
@@ -27,7 +27,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/authorizations-core/package.json
+++ b/packages/authorizations-core/package.json
@@ -14,23 +14,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/authorizations-core/package.json
+++ b/packages/authorizations-core/package.json
@@ -27,7 +27,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/dl-axios/package.json
+++ b/packages/dl-axios/package.json
@@ -19,23 +19,21 @@
   "license": "MIT",
   "author": "Robert McGuinness",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/dl-axios/package.json
+++ b/packages/dl-axios/package.json
@@ -32,7 +32,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/dl-core/package.json
+++ b/packages/dl-core/package.json
@@ -19,23 +19,21 @@
   "license": "MIT",
   "author": "Robert McGuinness",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/dl-core/package.json
+++ b/packages/dl-core/package.json
@@ -32,7 +32,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/dockyard/package.json
+++ b/packages/dockyard/package.json
@@ -19,23 +19,21 @@
   "license": "MIT",
   "author": "Greg Martin <greg.martin@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/dockyard/package.json
+++ b/packages/dockyard/package.json
@@ -32,7 +32,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/env-var/package.json
+++ b/packages/env-var/package.json
@@ -21,23 +21,21 @@
     "Evan Sharp <evan.sharp@availity.com> (https://github.com/TheSharpieOne)"
   ],
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/env-var/package.json
+++ b/packages/env-var/package.json
@@ -34,7 +34,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/exceptions-axios/package.json
+++ b/packages/exceptions-axios/package.json
@@ -14,23 +14,21 @@
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/exceptions-axios/package.json
+++ b/packages/exceptions-axios/package.json
@@ -27,7 +27,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/exceptions-core/package.json
+++ b/packages/exceptions-core/package.json
@@ -14,23 +14,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/exceptions-core/package.json
+++ b/packages/exceptions-core/package.json
@@ -27,7 +27,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/message-core/package.json
+++ b/packages/message-core/package.json
@@ -31,7 +31,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/message-core/package.json
+++ b/packages/message-core/package.json
@@ -18,23 +18,21 @@
   "license": "MIT",
   "author": "Kasey Powers <kasey.powers@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/native-form/package.json
+++ b/packages/native-form/package.json
@@ -33,7 +33,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/native-form/package.json
+++ b/packages/native-form/package.json
@@ -20,23 +20,21 @@
   "license": "MIT",
   "author": "Evan Sharp <evan.sharp@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/relay-id/package.json
+++ b/packages/relay-id/package.json
@@ -31,7 +31,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/relay-id/package.json
+++ b/packages/relay-id/package.json
@@ -18,23 +18,21 @@
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/resolve-url/package.json
+++ b/packages/resolve-url/package.json
@@ -19,23 +19,21 @@
   "license": "MIT",
   "author": "Rob McGuinness <rob.mcguinness@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/resolve-url/package.json
+++ b/packages/resolve-url/package.json
@@ -32,7 +32,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/upload-core/package.json
+++ b/packages/upload-core/package.json
@@ -33,7 +33,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --clean --dts",
     "dev": "tsup src/index.ts --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/upload-core/package.json
+++ b/packages/upload-core/package.json
@@ -20,23 +20,21 @@
   "license": "MIT",
   "author": "Robert McGuinness <rob.mcguinness@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+    "build": "tsup src/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/user-activity-broadcaster/package.json
+++ b/packages/user-activity-broadcaster/package.json
@@ -28,7 +28,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm --dts",
+    "build": "tsup src/index.js --format esm --clean --dts",
     "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/user-activity-broadcaster/package.json
+++ b/packages/user-activity-broadcaster/package.json
@@ -15,23 +15,21 @@
   "license": "MIT",
   "author": "Joe Spanbauer <joseph.spanbauer@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.js --format esm,cjs --dts",
-    "dev": "tsup src/index.js --format esm,cjs --watch --dts",
+    "build": "tsup src/index.js --format esm --dts",
+    "dev": "tsup src/index.js --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -32,7 +32,7 @@
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --clean --dts",
     "dev": "tsup src/index.ts --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",

--- a/packages/yup/package.json
+++ b/packages/yup/package.json
@@ -19,23 +19,21 @@
   "license": "MIT",
   "author": "Kyle Gray <kyle.gray@availity.com>",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.js"
     }
   },
   "engines": {
     "node": "^22.0.0 || ^24.0.0"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts",
-    "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
+    "build": "tsup src/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts --format esm --watch --dts",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "clean": "rm -rf node_modules && rm -rf dist",


### PR DESCRIPTION
- Remove CJS output from all packages (the CJS build was bugged)
 - Add `--clean` flag to tsup build commands to prevent stale output files from lingering between builds

  ## Changes

  - Removed `--format cjs` from tsup build scripts across all 18 packages
  - Removed `main` pointing to `.cjs` and `require` export conditions from package.json files
  - Added `--clean` flag so tsup wipes `dist/` before each build" 

